### PR TITLE
check_pwd fix 

### DIFF
--- a/tools/create
+++ b/tools/create
@@ -46,7 +46,8 @@
 
 # Check that the current working directory is *not* already a Git repo.
 function check_pwd {
-    if test $(git status > /dev/null 2>&1)
+    success=$(git status > /dev/null 2>&1; echo $?)
+    if [[ ${success} -eq 0 ]];
     then
         echo "ERROR: you are already inside a Git repository."
         exit 2


### PR DESCRIPTION
The check_pwd function in _tools/create_ now successfully gets the return code from git status.  I tested  it locally, seems to work alright.  The syntax to check the return code could be used on the clone_and_push function too I think.
