### PR TITLE
Quote INSTRUCTORS in tools/create

### DIFF
--- a/tools/create
+++ b/tools/create
@@ -132,7 +132,7 @@ WORKSHOP_ID=$1
 REPOSITORY_PATH=./$1
 TITLE="$2"
 OWNER=$3
-INSTRUCTORS=${OWNER} ${@:4}
+INSTRUCTORS="${OWNER} ${@:4}"
 WORKSHOP_URL=https://github.com/${OWNER}/${WORKSHOP_ID}
 REPOSITORY_DEFAULTS=,\"has_issues\":false,\"has_wiki\":false,\"has_downloads\":false
 


### PR DESCRIPTION
INSTRUCTORS isn't recognized as a list unless quoted. Appears to solve Issue #23 and #33. Successfully added @gvwilson as a collaborator to my test case using the command: 
`tools/create 2015-06-18-esu "Euphoric State University" drlabratory gvwilson`
