### PR TITLE
Problems using HTTPS URL to clone from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ the identifier for your workshop is `2015-07-01-esu`.
 2.  Clone it to your desktop using
 
     ~~~
-    $ git clone https://github.com:/ghopper/2015-07-01-esu.git
+    $ git clone https://github.com/ghopper/2015-07-01-esu.git
     ~~~
 
     It's OK if you get the message


### PR DESCRIPTION
When pushing to a GitHub repository using HTTPS, there are problems if using a slightly older version of Git, in that it does not prompt for a username and password when you try to push to the remote but just reports a 403 access error. This is fixed in Git 1.9.3 but doesn't work in Git 1.7.1, which is the default on RHEL 6. I haven't checked any intermediate versions.

There is a workaround, which is to change the URL from `https://github.com/ghopper/2015-07-01-esu.git` to `https://ghopper@github.com/ghopper/2015-07-01-esu.git` but this is more complex in that:
- you can't just copy and paste the URL from the GitHub page
- there are two different usernames in the URL when you are directly cloning from someone else's repository (although this is not the case here)

How can we help anyone who has this problem without overcomplicating the "happy path" instructions?
- add in the username to the URL here, even though it is not necessary with newer versions of Git
- add a troubleshooting section to the instructions
- list a recent version of Git as a dependency (may not be easily available to everyone)
- leave everything as is and resolve problems on the mailing list (but some organizers may waste time before asking for help, even if they eventually do so)

[I've removed an unneeded colon from a URL, but that isn't the main point of this pull request.]
