### PR TITLE
Further tidy-up based on email feedback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,107 +6,58 @@ repository directly on GitHub.  Instead, follow the instructions below
 to create a website repository for your workshop (and possibly a
 second repository for your learners to use in your Git lessons).
 
-### Dependencies
+> If you are teaching Git, you should create a separate repository for
+> learners to use in that lesson.  You should not have them use the
+> workshop website repository because:
+> 
+> *   your workshop website repository contains many files that
+>     most learners don't need to see during the lesson, and
+> 
+> *   you probably don't want to accidentally merge a damaging pull
+>     request from a novice Git user into your workshop's website while
+>     you are using it to teach.
 
-*Note that these dependencies are not critical to creating a workshop
-website. If you aren't able to install them successfully (and/or you just
-can't be bothered), all that means is you won't be able to preview
-the website locally on your computer. Every time you push a change to your
-website respository the live website will update automatically, so you can
-simply check your changes on the live site instead.*  
-
-In order to preview the workshop website locally on your computer,
-Jekyll 1.0.3 or later must be installed.
-
-1.  Check that you have Ruby installed on your computer (`ruby -v`
-    from the command line).
-
-2. Install `github-pages`:
-
-    ~~~
-    $ gem install github-pages
-    ~~~
-
-    or if that doesn't work:
-
-    ~~~
-    $ gem install jekyll
-    $ gem install kramdown
-    ~~~
-
-    We use Kramdown to translate Markdown into HTML, instead of the
-    default Redcarpet, because Kramdown handles Markdown inside HTML
-    blocks.
-
-3.  Install the Python YAML module.  If you are using the Anaconda
-    Python distribution, you probably already have it; if you don't,
-    you can install it with:
-
-    ~~~
-    $ conda install pyyaml
-    ~~~
-
-    If you are using some other distribution, you can install it using
-    Pip:
-
-    ~~~
-    $ pip install pyyaml
-    ~~~
-
-    and if you are on Debian Linux, you can use:
-
-    ~~~
-    $ apt-get install python-yaml
-    ~~~
-
-### One Repository or Two?
-
-If you are teaching Git, you should create a separate repository for
-learners to use in that lesson.  You should not have them use the
-workshop website repository because:
-
-*   your workshop website repository contains many files that
-    most learners don't need to see during the lesson, and
-
-*   you probably don't want to accidentally merge a damaging pull
-    request from a novice Git user into your workshop's website while
-    you are using it to teach.
-
-### Semi-Automated Installation
+## Semi-Automated Setup
 
 1.  Download the workshop website creation script from
     [http://files.software-carpentry.org/workshop-create](http://files.software-carpentry.org/workshop-create).
 
 2.  Make sure that you are *not* inside another Git repository.
 
-3.  Run that script with no parameters - it will print a help message telling you what parameters it needs.
+3.  Run the workshop website creation script with no parameters - it
+    will print a help message telling you what parameters it needs.
 
 4.  Run the script with those parameters.
 
 5.  Go into your newly-created repository.
 
-6.  Edit `index.html`.  (Hints are embedded in the file, and full instructions are below.)
+6.  Edit `index.html`.  Hints are embedded in the file, and full
+    instructions are in [CUSTOMIZATION.md](CUSTOMIZATION.md).
 
-7.  [If you installed the dependencies...] Check your changes by running `tools/check.py` 
-    inside your repository.
+7.  If you have installed the software described below:
 
-8.  [If you installed the dependencies...] Preview your changes by running `tools/preview` 
-    and looking at `_site/index.html`.
+    1.  Check your changes by running `tools/check.py` inside your
+        repository.
 
-9.  When it all looks good (or if you didn't install the dependencies for checking and previewing locally), commit your changes and push to the `gh-pages` branch of your repository.
+    2.  Preview your changes by running `tools/preview` and looking at
+        `_site/index.html`.
 
-10. Send the workshop coordinators the URL for your GitHub repository (*not* the URL for the workshop website).
+8.  Commit your changes and push to the `gh-pages` branch of your
+    repository.
+
+9.  Send the workshop coordinators the URL for your GitHub repository.
 
 If the identifier for your workshop is `2015-07-01-esu`, and your
 GitHub username is `ghopper`, your workshop repository will be
 `https://github.com/ghopper/2015-07-01-esu` and the website for your
-workshop will be `https://ghopper.github.io/2015-07-01-esu`.
+workshop will be `https://ghopper.github.io/2015-07-01-esu`.  (Note:
+the workshop coordinators will want the former URL, not the latter.)
 
-### Manual Installation
+## Manual Setup
 
 You can set up your repository manually instead of using the automated
-`create` script.  As above, we will assume that your user ID is `ghopper` and
-the identifier for your workshop is `2015-07-01-esu`.
+`create` script.  As above, we will assume that your user ID is
+`ghopper` and the identifier for your workshop is `2015-07-01-esu`.
 
 1.  Create an empty repository on GitHub called `2015-07-01-esu`.
 
@@ -129,38 +80,82 @@ the identifier for your workshop is `2015-07-01-esu`.
     $ git remote add origin https://github.com/ghopper/2015-07-01-esu.git
     ~~~
 
-5.  Edit `index.html`. (Hints are embedded in the file, and full instructions
-    are below.)
+5.  Edit `index.html`.  Hints are embedded in the file, and full
+    instructions are in [CUSTOMIZATION.md](CUSTOMIZATION.md).
 
-6.  [If you installed the dependencies...] Check your changes by running
+6.  If you have installed the software described below:
 
-    ~~~
-    $ tools/check.py
-    ~~~
+    1.  Check your changes by running `tools/check.py` inside your
+        repository.
 
-    inside your repository.
+    2.  Preview your changes by running `tools/preview` and looking at
+        `_site/index.html`.
 
-7.  [If you installed the dependencies...] Preview your changes by running
-
-    ~~~
-    $ tools/preview
-    ~~~
-
-    and looking at `_site/index.html`.
-
-8.  When it all looks good (or if you didn't install the dependencies 
-    for checking and previewing locally),commit your changes and push 
-    to the `gh-pages` branch of your repository.
-
-9.  Manually add the other instructors as collaborators to your Github
+7.  Commit your changes and push to the `gh-pages` branch of your
     repository.
 
-10. Send the workshop coordinators the URL for your GitHub repository (*not* the
-    URL for the workshop website).
+8.  Manually add the other instructors as collaborators to your Github
+    repository.
+
+9.  Send the workshop coordinators the URL for your GitHub repository.
 
 Note that SSH cloning (as opposed to the HTTPS cloning used above)
-will also work for those who are familiar with how to set up SSH keys
-with GitHub.
+will also work for those who have set up SSH keys with GitHub.
+
+## Previewing Changes Locally
+
+In order to preview the workshop website locally on your computer,
+you must install the software described below.
+
+> If you aren't able to install this software (or you just can't be
+> bothered), you can still create a website for your workshop.  Every
+> time you push a change to your website respository the live website
+> will update automatically, so you can check your changes on the live
+> site instead of locally.
+
+1.  Jekyll 1.0.3
+
+    1.  Check that you have Ruby installed on your computer (`ruby -v`
+        from the command line).
+
+    2. Install `github-pages`:
+
+        ~~~
+        $ gem install github-pages
+        ~~~
+
+        or if that doesn't work:
+
+        ~~~
+        $ gem install jekyll
+        $ gem install kramdown
+        ~~~
+
+        We use Kramdown to translate Markdown into HTML, instead of
+        the default Redcarpet, because Kramdown handles Markdown
+        inside HTML blocks.
+
+2.  The Python YAML module
+
+    If you are using the Anaconda Python distribution, you probably
+    already have it; if you don't, you can install it with:
+
+    ~~~
+    $ conda install pyyaml
+    ~~~
+
+    If you are using some other distribution, you can install the
+    Python YAML module using Pip:
+
+    ~~~
+    $ pip install pyyaml
+    ~~~
+
+    and if you are on Debian Linux, you can use:
+
+    ~~~
+    $ apt-get install python-yaml
+    ~~~
 
 ## For More Information
 


### PR DESCRIPTION
1. Moved the software installation instructions down so that "how I set up" is the first thing readers see.
2. Changed titles.
3. Changes "customization instructions below" to link to `CUSTOMIZATION.md`.
4. Changed nested of software installation instructions so that PyYAML wasn't under Jekyll.
