### PR TITLE
Fix sed to print blank formatting lines

### DIFF
--- a/tools/create
+++ b/tools/create
@@ -129,7 +129,7 @@ function main {
 if test $# -lt 3
 then
     echo ""
-    sed -n 's/^## //p' $0
+    sed -n 's/^##//p' $0
     echo ""
     exit 1
 fi


### PR DESCRIPTION
The existing sed fails to print the blank formatting lines because they don't have a space after them (likely due to editor stripping).

This changes the sed to print all lines which start with "##"
