### PR TITLE
Add check for hyphens in workshop_id

### DIFF
--- a/tools/create
+++ b/tools/create
@@ -11,7 +11,8 @@
 ## - workshop_id: the identifier provide by Software Carpentry for the
 ##   workshop that you will be running. It will be used for the name of
 ##   the Git repository and must be formated as YYYY-MM-DD-site, e.g.,
-##   '2015-06-18-esu'. Hyphens must separate the date and site name.
+##   '2015-06-18-esu'. The year, month, day, and site must be separated
+##   by hyphens rather than underscores or some other character.
 ##
 ## - title: the title of the workshop that you will be running.
 ##   It should be multi-word and must be enclose with single or double

--- a/tools/create
+++ b/tools/create
@@ -10,8 +10,8 @@
 ##
 ## - workshop_id: the identifier provide by Software Carpentry for the
 ##   workshop that you will be running. It will be used for the name of
-##   the Git repository and is a name like YYYY-MM-DD-site, e.g.,
-##   '2015-06-18-esu'.
+##   the Git repository and must be formated as YYYY-MM-DD-site, e.g.,
+##   '2015-06-18-esu'. Hyphens must separate the date and site name.
 ##
 ## - title: the title of the workshop that you will be running.
 ##   It should be multi-word and must be enclose with single or double
@@ -48,6 +48,15 @@ function check_pwd {
         echo "ERROR: you are already inside a Git repository."
         exit 2
     fi
+}
+
+function check_hyphens {
+  success=$(echo ${WORKSHOP_ID} | grep -v "-" > /dev/null 2>&1; echo $?)
+  if [[ ${success} -eq 0 ]];
+  then
+      echo "ERROR: workshop_id must contain hyphens for the date."
+      exit 2
+  fi
 }
 
 # Create the remote repository.
@@ -119,6 +128,7 @@ function end_message {
 # Main driver.
 function main {
     check_pwd
+    check_hyphens
     create_repo
     set_team
     clone_and_push


### PR DESCRIPTION
Checks for the presence of hyphens in workshop_id so we can enforce some kind of uniformity in naming.

Partially addresses #45 

This may conflict with my other PR
