### PR TITLE
Fix width attribute in Eventbrite iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 <iframe
   src="//www.eventbrite.com/tickets-external?eid={{page.eventbrite}}&ref=etckt"
   frameborder="0"
-  pwidth="100%"
+  width="100%"
   height="206px"
   scrolling="auto">
 </iframe>


### PR DESCRIPTION
The `width` attribute on the eventbrite iframe had a typo as `pwidth` which meant it didn't actually get set to 100% width.
