### PR TITLE
Wrap contents in div.row tags as needed by Bootstrap

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,10 +12,12 @@
   </head>
   <body>
     <div class="container">
-      <div class="span10 offset1">
-        {% include banner.html %}
-        {{content}}
-        {% include footer.html %}
+      <div class="row">
+        <div class="span10 offset1">
+          {% include banner.html %}
+          {{content}}
+          {% include footer.html %}
+        </div>
       </div>
     </div>
     {% include javascript.html %}

--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -19,39 +19,41 @@
   </head>
   <body>
     <div class="container">
-      <div class="span10 offset1">
-        {% include banner.html %}
-        <div class="hero-unit">
-          <div class="row-fluid">
-            <div class="span10">
-              <h2>{{page.venue}}</h2>
-	    </div>
+      <div class="row">
+        <div class="span10 offset1">
+          {% include banner.html %}
+          <div class="hero-unit">
+            <div class="row-fluid">
+              <div class="span10">
+                <h2>{{page.venue}}</h2>
+              </div>
+            </div>
+            <div class="row-fluid">
+              <div class="span6">
+                <p>{{page.humandate}}</p>
+                <p>{% if page.humantime %}{{page.humantime}}{% endif %}</p>
+              </div>
+              <div class="span6">
+                <p>
+                  <strong>Instructors:</strong>
+                  {% if page.instructor %}
+                  {{page.instructor | join: ', ' %}}
+                  {% else %}
+                  to be announced.
+                  {% endif %}
+                </p>
+                {% if page.helper %}
+                <p>
+                  <strong>Helpers:</strong>
+                  {{page.helper | join: ', ' %}}
+                </p>
+                {% endif %}
+              </div>
+            </div>
           </div>
-          <div class="row-fluid">
-	    <div class="span6">
-              <p>{{page.humandate}}</p>
-              <p>{% if page.humantime %}{{page.humantime}}{% endif %}</p>
-	    </div>
-	    <div class="span6">
-	      <p>
-		<strong>Instructors:</strong>
-		{% if page.instructor %}
-		{{page.instructor | join: ', ' %}}
-		{% else %}
-		to be announced.
-		{% endif %}
-	      </p>
-	      {% if page.helper %}
-	      <p>
-		<strong>Helpers:</strong>
-		{{page.helper | join: ', ' %}}
-	      </p>
-	      {% endif %}
-	    </div>
-          </div>
+          {{content}}
+          {% include footer.html %}
         </div>
-        {{content}}
-        {% include footer.html %}
       </div>
     </div>
     {% include javascript.html %}


### PR DESCRIPTION
To get the correct margins and paddings, Bootstrap expects all .span\* elements to be wrapped in a .row or .row-fluid element. On the current template, the left and right text margins are not the same, but with this fix they are.
