### PR TITLE
Add language field to YAML header

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -29,6 +29,10 @@ in its header:
     'United-States'.  This is used to look up flags for display in the
     main web site.
 
+*   `language` is the language that will be used in the workshop.
+    It must be a
+    [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+
 *   `latlng` is the latitude and longitude of the workshop site (so we
     can put a pin on our map).  You can use
     [this site](http://itouchmap.com/latlong.html) to find these

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@ root: .
 venue: Some University
 address: 456 Main St #123 Somewhere, SW
 country: Some-Country
+language: en
 latlng: 12.34, -56.78
 humandate: Jan 02-03, 2015
 humantime: 9:00 am - 4:30 pm

--- a/tools/check.py
+++ b/tools/check.py
@@ -123,6 +123,25 @@ COUNTRIES = [
     'Zimbabwe'
 ]
 
+LANGUAGES = [
+    'aa', 'ab', 'ae', 'af', 'ak', 'am', 'an', 'ar', 'as', 'av', 'ay', 'az',
+    'ba', 'be', 'bg', 'bh', 'bi', 'bm', 'bn', 'bo', 'br', 'bs', 'ca', 'ce',
+    'ch', 'co', 'cr', 'cs', 'cu', 'cv', 'cy', 'da', 'de', 'dv', 'dz', 'ee',
+    'el', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'ff', 'fi', 'fj', 'fo', 'fr',
+    'fy', 'ga', 'gd', 'gl', 'gn', 'gu', 'gv', 'ha', 'he', 'hi', 'ho', 'hr',
+    'ht', 'hu', 'hy', 'hz', 'ia', 'id', 'ie', 'ig', 'ii', 'ik', 'io', 'is',
+    'it', 'iu', 'ja', 'jv', 'ka', 'kg', 'ki', 'kj', 'kk', 'kl', 'km', 'kn',
+    'ko', 'kr', 'ks', 'ku', 'kv', 'kw', 'ky', 'la', 'lb', 'lg', 'li', 'ln',
+    'lo', 'lt', 'lu', 'lv', 'mg', 'mh', 'mi', 'mk', 'ml', 'mn', 'mr', 'ms',
+    'mt', 'my', 'na', 'nb', 'nd', 'ne', 'ng', 'nl', 'nn', 'no', 'nr', 'nv',
+    'ny', 'oc', 'oj', 'om', 'or', 'os', 'pa', 'pi', 'pl', 'ps', 'pt', 'qu',
+    'rm', 'rn', 'ro', 'ru', 'rw', 'sa', 'sc', 'sd', 'se', 'sg', 'si', 'sk',
+    'sl', 'sm', 'sn', 'so', 'sq', 'sr', 'ss', 'st', 'su', 'sv', 'sw', 'ta',
+    'te', 'tg', 'th', 'ti', 'tk', 'tl', 'tn', 'to', 'tr', 'ts', 'tt', 'tw',
+    'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'wo', 'xh', 'yi',
+    'yo', 'za', 'zh', 'zu'
+]
+
 
 def add_error(msg, errors):
     """
@@ -154,7 +173,6 @@ def add_suberror(msg, errors):
     """
     errors.append("\t{0}".format(msg))
 
-
 def look_for_fixme(func):
     '''Decorator to see whether a value starts with FIXME.'''
     def inner(arg):
@@ -181,6 +199,11 @@ def check_country(country):
     '''A valid country is in the list of recognized countries.'''
     return country in COUNTRIES
 
+
+@look_for_fixme
+def check_language(language):
+    """A valid language is a ISO 639-1 code."""
+    return language in LANGUAGES
 
 @look_for_fixme
 def check_humandate(date):
@@ -281,6 +304,9 @@ HANDLERS = {
     'country':    (True, check_country,
                    'country invalid: must use full hyphenated name from: ' +
                    ' '.join(COUNTRIES)),
+
+    'language' :  (False,  check_language,
+                   'language invalid: must be a ISO 639-1 code'),
 
     'humandate':  (True, check_humandate,
                    'humandate invalid. Please use three-letter months like ' +

--- a/tools/test_check.py
+++ b/tools/test_check.py
@@ -40,6 +40,18 @@ def test_check_country_correct_unhyphenated():
 def test_check_country_correct_hyphenated():
     assert check.check_country("United-Kingdom")
 
+def test_check_language_none():
+    assert not check.check_layout(None)
+
+def test_check_language_name():
+    assert not check.check_layout('english')
+
+def test_check_language_upper_name():
+    assert not check.check_layout('English')
+
+def test_check_language_correct():
+    assert check.check_layout('en')
+
 def test_check_humandate():
     assert check.check_humandate("Feb 18-20, 2525")
 


### PR DESCRIPTION
In https://github.com/swcarpentry/bc/issues/604 I had suggest that we track the language used at the workshops. This is the pull request for that and include:
- Change in `index.html`.
- Change in `CUSTOMIZATION.md`.
- Change on the validator.
- New tests for the validator.
