### PR TITLE
Add words about the need for a web browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,14 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 <h2 id="setup">Setup</h2>
 
 <p>
+  To participate in a Software Carpentry workshop, you will need 
+  access to the software described below. In addition, you will 
+  need a web browser 
+  <a href='https://help.github.com/articles/supported-browsers/'
+  >able to access github.com</a> and run the 
+  <a href='http://ipython.org/ipython-doc/2/install/install.html#browser-compatibility'
+  >IPython notebook</a>. It is probably worth updating your operating 
+  system and web browser before attending. 
   <a href="setup/index.html">This page</a> has instructions on testing
   that you have the right software installed.
 </p>

--- a/index.html
+++ b/index.html
@@ -468,8 +468,9 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
     <p>
       We will teach Python using the IPython notebook, a programming environment
       that runs in a web browser. For this to work you will need a reasonably
-      up-to-date browser. The Chrome (version 13 and above), Safari (version 5
-      and above) and Firefox (version 6 and above) browsers are supported.
+      up-to-date browser. The current versions of the Chrome, Safari and
+      Firefox browsers are all supported (some older browsers, including 
+      Internet Explorer version 9 and below, are not).
     </p>
 
   <div class="row">

--- a/index.html
+++ b/index.html
@@ -290,12 +290,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 <p>
   To participate in a Software Carpentry workshop, you will need 
   access to the software described below. In addition, you will 
-  need a web browser 
-  <a href='https://help.github.com/articles/supported-browsers/'
-  >able to access github.com</a> and run the 
-  <a href='http://ipython.org/ipython-doc/2/install/install.html#browser-compatibility'
-  >IPython notebook</a>. It is probably worth updating your operating 
-  system and web browser before attending. 
+  need an up-to-date web browser.
   <a href="setup/index.html">This page</a> has instructions on testing
   that you have the right software installed.
 </p>
@@ -402,14 +397,17 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   </div>
 <div> <!-- End of 'shell' section. -->
 
-<div id="git"> <!-- Start of 'Git' section. -->
+<div id='git'> <!-- Start of 'Git' section. GitHub browser compatability
+           is given at https://help.github.com/articles/supported-browsers/-->
   <h3>Git</h3>
 
   <p>
     Git is a version control system that lets you track who made changes
     to what when and has options for easily updating a shared or public
     version of your code
-    on <a href="https://github.com/">github.com</a>.
+    on <a href="https://github.com/">github.com</a>. You will need a
+    supported web browser (current versions of Chrome, Firefox or Safari,
+    or Internet Explorer version 9 or above).
   </p>
 
   <div class="row">
@@ -447,7 +445,10 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   </div>
 </div> <!-- End of 'Git' section. -->
 
-<div id="python"> <!-- Start of 'Python' section. -->
+<div id="python"> <!-- Start of 'Python' section. Remove the second paragrapph if
+           the workshop will teach Python using something other than
+           the IPython notebook.
+           Details at http://ipython.org/ipython-doc/2/install/install.html#browser-compatibility -->
   <h3>Python</h3>
 
   <p>
@@ -462,6 +463,13 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <strong>please make sure you install Python version 2.x and not version 3.x</strong>
       (e.g., 2.7 is fine but not 3.4).
       Python 3 introduced changes that will break some of the code we teach during the workshop.
+    </p>
+
+    <p>
+      We will teach Python using the IPython notebook, a programming environment
+      that runs in a web browser. For this to work you will need a reasonably
+      up-to-date browser. The Chrome (version 13 and above), Safari (version 5
+      and above) and Firefox (version 6 and above) browsers are supported.
     </p>
 
   <div class="row">

--- a/index.html
+++ b/index.html
@@ -406,7 +406,8 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
     to what when and has options for easily updating a shared or public
     version of your code
     on <a href="https://github.com/">github.com</a>. You will need a
-    supported web browser (current versions of Chrome, Firefox or Safari,
+    <a href="https://help.github.com/articles/supported-browsers/">supported</a>
+    web browser (current versions of Chrome, Firefox or Safari,
     or Internet Explorer version 9 or above).
   </p>
 
@@ -445,7 +446,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   </div>
 </div> <!-- End of 'Git' section. -->
 
-<div id="python"> <!-- Start of 'Python' section. Remove the second paragrapph if
+<div id="python"> <!-- Start of 'Python' section. Remove the third paragraph if
            the workshop will teach Python using something other than
            the IPython notebook.
            Details at http://ipython.org/ipython-doc/2/install/install.html#browser-compatibility -->
@@ -469,8 +470,10 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       We will teach Python using the IPython notebook, a programming environment
       that runs in a web browser. For this to work you will need a reasonably
       up-to-date browser. The current versions of the Chrome, Safari and
-      Firefox browsers are all supported (some older browsers, including 
-      Internet Explorer version 9 and below, are not).
+      Firefox browsers are all <a 
+      href='http://ipython.org/ipython-doc/2/install/install.html#browser-compatibility'>supported</a> 
+      (some older browsers, including Internet Explorer version 9 
+      and below, are not).
     </p>
 
   <div class="row">


### PR DESCRIPTION
Neither IPython notebooks nor github.com will
work well with old web browsers. This commit
adds text to the start of the setup section
asking participants to make sure they have an
up to date web browser (linking to the list
of supported browsers for github and the
IPython notebook). We also sugest that the
OS should be updated.

This fixes #104, but the exact wording may
need a tweak.
