### PR TITLE
Updated mac git instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,7 +399,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 	<strong>For OS X 10.8 and higher</strong>, install Git for Mac
 	by downloading and running
 	<a href="http://sourceforge.net/projects/git-osx-installer/files/latest/download">the installer</a>.
-	After installing Git, there will not be anything in your <pre>/Applications</pre> folder, 
+	After installing Git, there will not be anything in your <code>/Applications</code> folder, 
 	as Git is a command line program.
 	<strong>For older versions of OS X (10.5-10.7)</strong> use the
 	most recent available installer for your

--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <p>
 	<strong>For OS X 10.8 and higher</strong>, install Git for Mac
 	by downloading and running
-	<a href="http://git-scm.com/downloads">the installer</a>.
+	<a href="http://sourceforge.net/projects/git-osx-installer/files/latest/download">the installer</a>.
 	<strong>For older versions of OS X (10.5-10.7)</strong> use the
 	most recent available installer for your
 	OS <a href="https://code.google.com/p/git-osx-installer/downloads/list">available

--- a/index.html
+++ b/index.html
@@ -399,8 +399,8 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 	<strong>For OS X 10.8 and higher</strong>, install Git for Mac
 	by downloading and running
 	<a href="http://sourceforge.net/projects/git-osx-installer/files/latest/download">the installer</a>.
-	After installing git, there will not be anything in your /Applications folder, as git is a 
-	command line program.
+	After installing Git, there will not be anything in your <pre>/Applications</pre> folder, 
+	as Git is a command line program.
 	<strong>For older versions of OS X (10.5-10.7)</strong> use the
 	most recent available installer for your
 	OS <a href="https://code.google.com/p/git-osx-installer/downloads/list">available

--- a/index.html
+++ b/index.html
@@ -399,6 +399,8 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 	<strong>For OS X 10.8 and higher</strong>, install Git for Mac
 	by downloading and running
 	<a href="http://sourceforge.net/projects/git-osx-installer/files/latest/download">the installer</a>.
+	After installing git, there will not be anything in your /Applications folder, as git is a 
+	command line program.
 	<strong>For older versions of OS X (10.5-10.7)</strong> use the
 	most recent available installer for your
 	OS <a href="https://code.google.com/p/git-osx-installer/downloads/list">available


### PR DESCRIPTION
It appears that the instructions for Mac on git-scm.com aren't being updated, but the binaries on sourceforge are. Pointed to the latest release download link, and added explanatory text stating nothing will show up in /Applications, as it was confusing some users.
