### PR TITLE
Fix favicon link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<link rel="shortcut icon" type="image/x-icon" href="{{site.swc_site}}/v5/favicon.ico" />
+<link rel="shortcut icon" type="image/x-icon" href="{{site.swc_site}}/favicon.ico" />
 <link href="{{site.swc_site}}/v5/css/bootstrap/bootstrap.css" rel="stylesheet" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link href="{{site.swc_site}}/v5/css/bootstrap/bootstrap-responsive.css" rel="stylesheet" />


### PR DESCRIPTION
Fix shortcut icon link to one that works (alternatively, the site template should be updated so that v5/favicon.ico goes somewhere--currently it gives a 404).
