### PR TITLE
Improve error message in `check.py`; remove redundant line in README.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,6 @@ You can set up your repository manually instead of using the automated
     $ git push origin gh-pages
     ~~~
 
-    ~~~
-    $ git push origin gh-pages
-    ~~~
-
 8.  Manually add the other instructors as collaborators to your Github
     repository.
 

--- a/tools/check.py
+++ b/tools/check.py
@@ -330,6 +330,18 @@ def check_validity(data, function, errors, error_msg):
         add_suberror('Offending entry is: "{0}"'.format(data), errors)
     return valid
 
+def check_blank_category(seen_categories, errors, error_msg):
+    '''Check for blank line in category headers.'''
+    if '' in seen_categories:
+        add_error(error_msg, errors)
+        blank_count = 0
+        while '' in seen_categories:
+            seen_categories.remove('')
+            blank_count += 1
+        add_suberror('{0} blank lines found in header'.format(blank_count),
+                     errors)
+        return False
+    return True
 
 def check_categories(left, right, errors, error_msg):
     '''Report set difference of categories.'''
@@ -414,6 +426,10 @@ def check_file(filename, data):
     is_valid &= check_repeated_categories(
         seen_categories, errors,
         'There are categories appearing twice or more')
+
+    # Do we have any blank lines in the header?
+    is_valid &= check_blank_category(seen_categories, errors,
+                                     'There are blank lines in the header')
 
     # Check whether we have missing or too many categories
     seen_categories = set(seen_categories)

--- a/tools/check.py
+++ b/tools/check.py
@@ -422,14 +422,14 @@ def check_file(filename, data):
             add_error(msg, errors)
             is_valid &= False
 
+    # Do we have any blank lines in the header?
+    is_valid &= check_blank_category(seen_categories, errors,
+                                     'There are blank lines in the header')
+
     # Do we have double categories?
     is_valid &= check_repeated_categories(
         seen_categories, errors,
         'There are categories appearing twice or more')
-
-    # Do we have any blank lines in the header?
-    is_valid &= check_blank_category(seen_categories, errors,
-                                     'There are blank lines in the header')
 
     # Check whether we have missing or too many categories
     seen_categories = set(seen_categories)


### PR DESCRIPTION
### Improve error message in `check.py`

Accidentally leaving a blank line in the `index.html` header, (e.g. if deleting the `eventbrite` key:value pair as indicated in the original file):

```
[...]
contact: someone@somewhere.org
etherpad: # FIXME (insert the URL for your Etherpad if you're using one)

---
[...]
```

gives an error concerning "superfluous categories", as `check.py` interprets the blank line as a category `''`:

```
$ tools/check.py 
INFO: Testing "./index.html"
ERROR: There are superfluous categories
ERROR:  Offending entries: set([''])
```

I had to read `check.py` in order to discover what the error meant. This PR involves addition of a `check_blank_category()` function that tests for blank lines, and reports the number it finds.
### Remove redundant line in README.py

There was a repeat of the `git push` instruction under manual instructions.
