### PR TITLE
Fixed link to go to old versions of git

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,7 +404,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 	as Git is a command line program.
 	<strong>For older versions of OS X (10.5-10.7)</strong> use the
 	most recent available installer for your
-	OS <a href="https://code.google.com/p/git-osx-installer/downloads/list">available
+	OS <a href="http://sourceforge.net/projects/git-osx-installer/files/">available
 	  here</a>.  Use the Leopard installer for 10.5 and the Snow
 	Leopard installer for 10.6-10.7.
       </p>


### PR DESCRIPTION
The code.google.com link from before went to a page with no versions of git for older Macs. I've linked to the sourceforge set of download links linked to from git-scm.com.
