### PR TITLE
Add new CSS classes in preparation for merging CSS with main site

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,8 +10,8 @@
     <title>Software Carpentry: {{ page.venue }}</title>
     {% include header.html %}
   </head>
-  <body>
-    <div class="container">
+  <body class="workshop">
+    <div class="container card">
       <div class="row">
         <div class="span10 offset1">
           {% include banner.html %}

--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -17,8 +17,8 @@
     <meta http-equiv="refresh" content="0; url={{page.redirect}}" />
     {% endif %}
   </head>
-  <body>
-    <div class="container">
+  <body class="workshop">
+    <div class="container card">
       <div class="row">
         <div class="span10 offset1">
           {% include banner.html %}


### PR DESCRIPTION
With these extra HTML classes, we can use the CSS from the main site (after swcarpentry/site#748 is merged) and the workshop template will render correctly.

Note that the stylesheet links in the HTML are not updated yet since I don't know the best way to keep separate local copies of the CSS, but still keep them in sync. So the stylesheet include tags will need updating, and will also need to reference the new swc-workshop-and-lesson.css in swcarpentry/site#748.
