### PR TITLE
Changing text and link of GitHub ribbon.

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -3,7 +3,7 @@
 ## Configuration File
 
 You must edit the `_config.yml` configuration file in the root directory of your workshop
-and change the URLS called `lesson_repo` and `lesson_site`
+and change the URLS called `workshop_repo` and `workshop_site`
 to point to the repository for the lesson and its GitHub Pages site respectively.
 If the URL for the repository is `https://github.com/gvwilson/2015-07-01-mistaktonic`,
 the URL for the website will be `http://gvwilson.github.io/2015-07-01-miskatonic`.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ please [get in touch](#getting-and-giving-help).
     and push your changes back to the repository.
 
 3.  Edit `_config.yml` in the same way
-    so that `lesson_repo` and `lesson_site`
+    so that `workshop_repo` and `workshop_site`
     are the URLs of your repository and your GitHub Pages website respectively.
 
     Note: the URL for your website is determined automatically

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 #--------------------------------------------------------------------------------
 # Values for this workshop - EDIT THIS SECTION.
 #--------------------------------------------------------------------------------
-lesson_repo     : "http://github.com/swcarpentry/workshop-template"
-lesson_site     : "http://swcarpentry.github.io/workshop-template"
+workshop_repo   : "http://github.com/swcarpentry/workshop-template"
+workshop_site   : "http://swcarpentry.github.io/workshop-template"
 #--------------------------------------------------------------------------------
 # Standard Software Carpentry settings - should not need to be modified.
 #--------------------------------------------------------------------------------

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,4 +1,4 @@
-<span id="github-ribbon"><a href="https://github.com/swcarpentry">Find us on GitHub</a></span>
+<span id="github-ribbon"><a href="{{site.workshop_repo}}">Find us on GitHub</a></span>
 <div class="banner">
   <a href="http://software-carpentry.org" title="Software Carpentry">
     <img alt="Software Carpentry banner" src="{{site.swc_site}}/img/software-carpentry-banner.png" />

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,4 +1,4 @@
-<span id="github-ribbon"><a href="https://github.com/swcarpentry/bc">Fork me on GitHub</a></span>
+<span id="github-ribbon"><a href="https://github.com/swcarpentry">Find us on GitHub</a></span>
 <div class="banner">
   <a href="http://software-carpentry.org" title="Software Carpentry">
     <img alt="Software Carpentry banner" src="{{site.swc_site}}/img/software-carpentry-banner.png" />

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,5 +3,5 @@
   <a class="label swc-blue-bg" href="{{site.swc_blog}}">Blog</a>
   <a class="label swc-blue-bg" href="{{site.swc_github}}">GitHub</a>
   <a class="label swc-blue-bg" href="{{site.swc_twitter}}">Twitter</a>
-  <a class="label swc-blue-bg" href="{{site.lesson_repo}}/issues/">Issues</a>
+  <a class="label swc-blue-bg" href="{{site.workshop_repo}}/issues/">Issues</a>
 </div>


### PR DESCRIPTION
This addresses #125 by changing the text of the GitHub ribbon to "Find us on GitHub"
and changing the link to point to the organization `https://github.com/swcarpentry`.
