### PR TITLE
index.html: Use HTTPS to access Eventbrite

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 -->
 {% if page.eventbrite %}
 <iframe
-  src="//www.eventbrite.com/tickets-external?eid={{page.eventbrite}}&ref=etckt"
+  src="https://www.eventbrite.com/tickets-external?eid={{page.eventbrite}}&ref=etckt"
   frameborder="0"
   width="100%"
   height="206px"


### PR DESCRIPTION
Avoid mixed active content errors like:

```
[14:18:33.243] Blocked loading mixed active content "http://ebmedia.eventbrite.com/s3-build/26966-rc2015-01-28-c6778b4/django/css/production/event_pages_C.css" @ https://efran.github.io/2015-04-09-UW/
[14:18:33.243] Blocked loading mixed active content "http://ebmedia.eventbrite.com/s3-build/26966-rc2015-01-28-c6778b4/django/js/production/legacy_event_pages.js" @ https://efran.github.io/2015-04-09-UW/
[14:18:33.248] Blocked loading mixed active content "http://ebmedia.eventbrite.com/s3-build/26966-rc2015-01-28-c6778b4/django/js/src/vendor/mixpanel-2.2.min.js" @ https://www.eventbrite.com/tickets-external?eid=15561681408&ref=etckt:372
```

when accessing Eventbrite [from workshop pages served over HTTPS](https://github.com/swcarpentry/workshop-template/issues/152).
The HTTPS approach [works for workshop pages served over HTTPS](https://github.com/swcarpentry/2015-02-05-toronto/pull/12),
and for workshop pages served over HTTP it's no less secure than the
old approach.
