### PR TITLE
Update SWC Windows Installer instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,11 +367,6 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
           Download the <a href="{{site.swc_installer}}">installer</a>.
 	</li>
 	<li>
-          If the file opens directly in the browser
-          select <strong>File&rarr;Save Page As</strong> to download it
-          to your computer.
-	</li>
-	<li>
           Double click on the file to run it.
 	</li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -361,7 +361,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       </p>
       <h4>Software Carpentry Installer</h4>
       <p><em>This installer requires an active internet connection.</em></p>
-      <p>After installing Python and Git Bash:</p>
+      <p>After Git Bash:</p>
       <ul>
 	<li>
           Download the <a href="{{site.swc_installer}}">installer</a>.


### PR DESCRIPTION
The Software Carpentry Windows Installer is now a self-contained windows installer. Therefore
it no longer relies on Python being installed or has the potential to open directly in the browser.
