### PR TITLE
Specify the version of Python to install.

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,6 +453,8 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
     a bit difficult, so we recommend an all-in-one installer.
   </p>
 
+    <p>Regardless of how you choose to install it, <strong>please make sure you install Python version 2.x and not version 3.x</strong> (e.g. 2.7 is fine but not 3.4). Python 3 introduced changes that will break some of the code we teach during the workshop.</p>
+
   <div class="row">
     <div class="col-md-4">
       <h4>Windows</h4>
@@ -462,7 +464,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
           install <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
 	</li>
 	<li>
-          Use all of the defaults for installation
+          Download the default Python 2 installer (do not follow the link to version 3). Use all of the defaults for installation
           <em>except</em> make sure to check <strong>Make Anaconda the
             default Python</strong>.
 	</li>
@@ -476,7 +478,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
           install <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
 	</li>
 	<li>
-          Use all of the defaults for installation
+          Download the default Python 2 installer (do not follow the link to version 3). Use all of the defaults for installation
           <em>except</em>
           make sure to check <strong>Make Anaconda the default Python</strong>.
 	</li>
@@ -495,7 +497,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <ol>
 	<li>
           Download the installer that matches your operating
-          system and save it in your home folder.
+          system and save it in your home folder. Download the default Python 2 installer (do not follow the link to version 3). 
 	</li>
 	<li>
           Open a terminal window.


### PR DESCRIPTION
The aim is to prevent attendees from installing Python 3.4 and reduce
the number of compatibility issues with the functions taught during
workshops (e.g. print and the urllib library). See
https://github.com/swcarpentry/workshop-template/issues/157

Feel free to suggest a better wording.
