### PR TITLE
Add accessibility information

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,31 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 </p>
 
 <!--
+  ACCESSIBILITY
+
+  Modify the block below to indicate what kinds of accessibility are available
+  for you workshop. If you cannot provide a particular kind of accessibility,
+  just clearly state in the paragraph below that it is not available.
+
+  If you're not sure what to include here see:
+  http://software-carpentry.org/workshops/checklists/accessibility.html Your
+  university's disability resource center should be able to help you figure out
+  what kinds of accessibility are available through the university.
+-->
+
+<p>
+  <strong>Accessibility:</strong>The building for this workshop meets all
+  Americans with Disabilities Act (ADA) physical facilities requirements. There
+  are accessible restrooms and dining options nearby. Materials will be provided
+  in advance of the workshop and large-print handouts are available are
+  available if needed by notifying the organizers in advance. At this time we do
+  not provide remote participation for this workshop, but are working on making
+  this possible in the future. If you have other accessibility needs
+  (e.g. sign-language interpreters, lactation facilities) please get in touch
+  and we will attempt to provide them.
+</p>
+
+<!--
   CONTACT EMAIL ADDRESS
 
   Display the contact email address set in the header.  If an address


### PR DESCRIPTION
Software Carpentry is committed to trying to make our workshops more accessible:
http://software-carpentry.org/workshops/checklists/accessibility.html

This adds an accessibility section to the template with draft language to help
prompt the organizers to consider this and get them started with the language.
