### PR TITLE
Remove forward reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,6 +343,52 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
   </div>
 </div> <!-- End of 'editor' section. -->
 
+<div> <!-- Start of 'Git' section. -->
+  <h3>Git</h3>
+
+  <p>
+    Git is a version control system that lets you track who made changes
+    to what when and has options for easily updating a shared or public
+    version of your code
+    on <a href="https://github.com/">github.com</a>.
+  </p>
+
+  <div class="row">
+    <div class="col-md-4">
+      <h4>Windows</h4>
+      <p>
+	Install Git for Windows by download and running
+	<a href="http://msysgit.github.io/">the installer</a>.
+	This will provide you with both Git and Bash in the Git Bash program.
+      </p>
+    </div>
+    <div class="col-md-4">
+      <h4>Mac OS X</h4>
+      <p>
+	<strong>For OS X 10.8 and higher</strong>, install Git for Mac
+	by downloading and running
+	<a href="http://sourceforge.net/projects/git-osx-installer/files/latest/download">the installer</a>.
+	After installing Git, there will not be anything in your <code>/Applications</code> folder, 
+	as Git is a command line program.
+	<strong>For older versions of OS X (10.5-10.7)</strong> use the
+	most recent available installer for your
+	OS <a href="http://sourceforge.net/projects/git-osx-installer/files/">available
+	  here</a>.  Use the Leopard installer for 10.5 and the Snow
+	Leopard installer for 10.6-10.7.
+      </p>
+    </div>
+    <div class="col-md-4">
+      <h4>Linux</h4>
+      <p>
+	If Git is not already available on your machine you can try to
+	install it via your distro's package manager. For Debian/Ubuntu run
+        <code>sudo apt-get install git</code> and for Fedora run
+        <code>sudo yum install git</code>.
+      </p>
+    </div>
+  </div>
+</div> <!-- End of 'Git' section. -->
+
 <div> <!-- Start of 'shell' section. -->
   <h3>The Bash Shell</h3>
 
@@ -355,9 +401,8 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
     <div class="col-md-4">
       <h4>Windows</h4>
       <p>
-	Install Git for Windows by download and running
-	<a href="http://msysgit.github.io/">the installer</a>.
-	This will provide you with both Git and Bash in the Git Bash program.
+	Bash should be installed on your computer as part of your Git
+	install (described above).
       </p>
       <h4>Software Carpentry Installer</h4>
       <p><em>This installer requires an active internet connection.</em></p>
@@ -397,51 +442,6 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
     </div>
   </div>
 <div> <!-- End of 'shell' section. -->
-
-<div> <!-- Start of 'Git' section. -->
-  <h3>Git</h3>
-
-  <p>
-    Git is a version control system that lets you track who made changes
-    to what when and has options for easily updating a shared or public
-    version of your code
-    on <a href="https://github.com/">github.com</a>.
-  </p>
-
-  <div class="row">
-    <div class="col-md-4">
-      <h4>Windows</h4>
-      <p>
-	Git should be installed on your computer as part of your Bash
-	install (described above).
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4>Mac OS X</h4>
-      <p>
-	<strong>For OS X 10.8 and higher</strong>, install Git for Mac
-	by downloading and running
-	<a href="http://sourceforge.net/projects/git-osx-installer/files/latest/download">the installer</a>.
-	After installing Git, there will not be anything in your <code>/Applications</code> folder, 
-	as Git is a command line program.
-	<strong>For older versions of OS X (10.5-10.7)</strong> use the
-	most recent available installer for your
-	OS <a href="http://sourceforge.net/projects/git-osx-installer/files/">available
-	  here</a>.  Use the Leopard installer for 10.5 and the Snow
-	Leopard installer for 10.6-10.7.
-      </p>
-    </div>
-    <div class="col-md-4">
-      <h4>Linux</h4>
-      <p>
-	If Git is not already available on your machine you can try to
-	install it via your distro's package manager. For Debian/Ubuntu run
-        <code>sudo apt-get install git</code> and for Fedora run
-        <code>sudo yum install git</code>.
-      </p>
-    </div>
-  </div>
-</div> <!-- End of 'Git' section. -->
 
 <div> <!-- Start of 'Python' section. -->
   <h3>Python</h3>


### PR DESCRIPTION
Move Git section to come before Bash Shell section to remove the forward reference in Windows setup.
Plus some associated rewording. 
We've already used this change in http://jrugis.github.io/2015-02-26-auckland
