### PR TITLE
Removed reference to "Make Anaconda the default python"

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,9 +485,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 	</li>
 	<li>
           Download the default Python 2 installer (do not follow the link to version 3).
-	  Use all of the defaults for installation
-          <em>except</em>
-          make sure to check <strong>Make Anaconda the default Python</strong>.
+	  Use all of the defaults for installation.
 	</li>
       </ul>
     </div>


### PR DESCRIPTION
Removed reference to "Make Anaconda the default python" in the MacOS install instructions -- there is no such option in the installer.
