### PR TITLE
Details about Software Carpentry installer

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,12 +359,13 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 	<a href="http://msysgit.github.io/">the installer</a>.
 	This will provide you with both Git and Bash in the Git Bash program.
       </p>
-      <h4>Software Carpentry Installer</h4>
+      <h4>Software Carpentry Windows Installer</h4>
+      <p>It installs and configures <code>nano</code> (<a href="{{site.swc_github}}/windows-installer">Among other things</a>)</p>
       <p><em>This installer requires an active internet connection.</em></p>
-      <p>After Git Bash:</p>
+      <p>After installing Git Bash:</p>
       <ul>
 	<li>
-          Download the <a href="{{site.swc_installer}}">installer</a>.
+          Download the <a href="{{site.swc_installer}}">Software Carpentry Windows installer</a>.
 	</li>
 	<li>
           Double click on the file to run it.

--- a/index.html
+++ b/index.html
@@ -370,11 +370,6 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
           Double click on the file to run it.
 	</li>
       </ul>
-      <p>
-	Information about the SWC Windows Installer,
-	including the source code, can be found at
-	<a href="https://github.com/swcarpentry/windows-installer">https://github.com/swcarpentry/windows-installer</a>.
-      </p>
     </div>
     <div class="col-md-4">
       <h4>Mac OS X</h4>


### PR DESCRIPTION
Many students see 2 links to `installer` and think they are the same, so they install only one.

So I think it would be useful to explicitly label the Software Carpentry Installer, I also
added a line that explains what the installer is supposed to do.
