### PR TITLE
README.md: Shorten the link text for the GitHub importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ template for creating websites for workshops.
 
 ## Creating a Repository
 
-1.  Go to [http://import.github.com/new?import_url=https://github.com/swcarpentry/workshop-template](http://import.github.com/new?import_url=https://github.com/swcarpentry/workshop-template).
+1.  Go to [GitHub's importer][import].
 
 2.  Click on "Check the URL".  (GitHub won't import until you've done this.)
 
@@ -218,3 +218,5 @@ If you find bugs in our instructions,
 or would like to suggest improvements,
 please [file an issue](https://github.com/swcarpentry/workshop-template/issues)
 or [mail us](mailto:admin@software-carpentry.org).
+
+[import]: http://import.github.com/new?import_url=https://github.com/swcarpentry/workshop-template


### PR DESCRIPTION
To avoid distracting folks with a large, in-your-face URL.  They can
always mouse over the link (or just click it) if they want to see
where it points.

I've also used a reference-style link.  The text we use for the link
and the URL we're pointing at are pretty orthogonal, so splitting them
up makes it easier to version each independently with a line-based
diff/merge tool like Git.  It's also easier to read the source text
without the long URL cluttering up the human-readable portion.

Previous discussion in #178.
