### PR TITLE
Modify the sqlite setup instructions for Windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,9 +609,8 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
     <div class="col-md-4">
       <h4 id="sql-windows">Windows</h4>
       <p>
-	Download the <a href="{{site.swc_files}}/sqlite3.exe">sqlite3
-	  program</a> and put it in the directory where you are running
-	examples.
+      The <a href="{{site.swc_github}}/windows-installer">Software Carpentry
+          Windows Installer</a> installs <code>sqlite3</code> for Windows.
       </p>
     </div>
     <div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -610,7 +610,8 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <h4 id="sql-windows">Windows</h4>
       <p>
       The <a href="{{site.swc_github}}/windows-installer">Software Carpentry
-          Windows Installer</a> installs <code>sqlite3</code> for Windows.
+          Windows Installer</a> installs <code>sqlite3</code> for Windows. If
+      you used the installer to configure `nano`, you don't need to run it again.
       </p>
     </div>
     <div class="col-md-4">


### PR DESCRIPTION
This is taken care by the Windows installer and the previous link to our files
page was broken. This fixes #192.
