### PR TITLE
Modify R setup instructions to include old Mac OS X

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,11 +574,14 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
     <div class="col-md-4">
       <h4 id="r-macosx">Mac OS X</h4>
       <p>
-        Install R by downloading and running
-        <a href="http://cran.r-project.org/bin/macosx/R-latest.pkg">this .pkg file</a>
-        from <a href="http://cran.r-project.org/index.html">CRAN</a>.
-        Also, please install the
-        <a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
+	<strong>For OS X 10.9 and higher</strong>, install R by downloading and running
+	<a href="http://cran.r-project.org/bin/macosx/R-latest.pkg">this .pkg file</a>
+	from <a href="http://cran.r-project.org/index.html">CRAN</a>.
+	<strong>For older versions of OS X (10.6-10.8)</strong> use 
+	<a href="http://cran.r-project.org/bin/macosx/R-3.1.3-snowleopard.pkg">this
+        other .pkg file</a>.
+	Also, and for all versions, please install the
+	<a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
       </p>
     </div>
     <div class="col-md-4">


### PR DESCRIPTION
Note that the version for all Mac OS X includes the version number, so it
should be updated with every new R release.

Fixes #176.
