### PR TITLE
Replace '<code>nano</code>' with 'nano'

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -43,7 +43,7 @@
 *   *What is the "Windows installer"?*
 
     We have built a small installation helper for Windows
-    that installs nano and `sqlite`, adds R to the path, and so on.
+    that installs nano and SQLite, adds R to the path, and so on.
     It is maintained in
     [https://github.com/swcarpentry/windows-installer](https://github.com/swcarpentry/windows-installer),
     which also has an up-to-date description of what it actually does.

--- a/FAQ.md
+++ b/FAQ.md
@@ -43,7 +43,7 @@
 *   *What is the "Windows installer"?*
 
     We have built a small installation helper for Windows
-    that installs `nano` and `sqlite`, adds R to the path, and so on.
+    that installs nano and `sqlite`, adds R to the path, and so on.
     It is maintained in
     [https://github.com/swcarpentry/windows-installer](https://github.com/swcarpentry/windows-installer),
     which also has an up-to-date description of what it actually does.

--- a/index.html
+++ b/index.html
@@ -609,20 +609,20 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <h4 id="sql-windows">Windows</h4>
       <p>
       The <a href="{{site.swc_github}}/windows-installer">Software Carpentry
-          Windows Installer</a> installs <code>sqlite3</code> for Windows. If
+          Windows Installer</a> installs SQLite for Windows. If
       you used the installer to configure nano, you don't need to run it again.
       </p>
     </div>
     <div class="col-md-4">
       <h4 id="sql-macosx">Mac OS X</h4>
       <p>
-	<code>sqlite3</code> comes pre-installed on Mac OS X.
+	SQLite comes pre-installed on Mac OS X.
       </p>
     </div>
     <div class="col-md-4">
       <h4 id="sql-linux">Linux</h4>
       <p>
-	<code>sqlite3</code> comes pre-installed on Linux.
+	SQLite comes pre-installed on Linux.
       </p>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -396,7 +396,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
     <div class="col-md-4">
       <h4 id="shell-linux">Linux</h4>
       <p>
-	The default shell is usually <code>bash</code>, but if your
+	The default shell is usually Bash, but if your
 	machine is set up differently you can run it by opening a
 	terminal and typing <code>bash</code>.  There is no need to
 	install anything.

--- a/index.html
+++ b/index.html
@@ -610,7 +610,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <p>
       The <a href="{{site.swc_github}}/windows-installer">Software Carpentry
           Windows Installer</a> installs <code>sqlite3</code> for Windows. If
-      you used the installer to configure `nano`, you don't need to run it again.
+      you used the installer to configure <code>nano</code>, you don't need to run it again.
       </p>
     </div>
     <div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
     <div class="col-md-4">
       <h4 id="editor-windows">Windows</h4>
       <p>
-	<code>nano</code> is the editor installed by the Software
+	nano is the editor installed by the Software
 	Carpentry Installer, it is a basic editor integrated into the
 	lesson material.
       </p>
@@ -339,7 +339,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 	We recommend
 	<a href="http://www.barebones.com/products/textwrangler/">Text Wrangler</a> or
 	<a href="http://www.sublimetext.com/">Sublime Text</a>.
-	In a pinch, you can use <code>nano</code>,
+	In a pinch, you can use nano,
 	which should be pre-installed.
       </p>
     </div>
@@ -347,7 +347,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <h4 id="editor-linux">Linux</h4>
       <p>
 	<a href="http://kate-editor.org/">Kate</a> is one option for
-	Linux users.  In a pinch, you can use <code>nano</code>, which
+	Linux users.  In a pinch, you can use nano, which
 	should be pre-installed.
       </p>
     </div>
@@ -371,7 +371,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
 	This will provide you with both Git and Bash in the Git Bash program.
       </p>
       <h4>Software Carpentry Windows Installer</h4>
-      <p>It installs and configures <code>nano</code> (<a href="{{site.swc_github}}/windows-installer">Among other things</a>)</p>
+      <p>It installs and configures nano (<a href="{{site.swc_github}}/windows-installer">Among other things</a>)</p>
       <p><em>This installer requires an active internet connection.</em></p>
       <p>After installing Git Bash:</p>
       <ul>
@@ -610,7 +610,7 @@ eventbrite: # FIXME (delete this if not used, otherwise uncomment and provide 12
       <p>
       The <a href="{{site.swc_github}}/windows-installer">Software Carpentry
           Windows Installer</a> installs <code>sqlite3</code> for Windows. If
-      you used the installer to configure <code>nano</code>, you don't need to run it again.
+      you used the installer to configure nano, you don't need to run it again.
       </p>
     </div>
     <div class="col-md-4">


### PR DESCRIPTION
The project refers to itself as [“GNU nano”](http://www.nano-editor.org/overview.php), and neither it nor
[Wikipedia](http://en.wikipedia.org/wiki/GNU_nano) use any code-like markup around the project name.

This also fixes some Markdown syntax that leaked into index.html.
