### PR TITLE
using find -exec to remove temporary files

### DIFF
--- a/tools/clean
+++ b/tools/clean
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Delete junk files.
-rm -rf $(find . -name '*~' -print)
-rm -rf $(find . -name '*.pyc' -print)
-rm -rf $(find . -name '.DS_Store' -print)
+find . -name '*~' -exec rm -rf {} \;
+find . -name '*.pyc' -exec rm -rf {} \;
+find . -name '.DS_Store' -exec rm -rf {} \;
 rm -rf _site


### PR DESCRIPTION
1) avoid problems with spaces
2) avoid messages when no file is found

fixes #214 
