### PR TITLE
Switching to two-letter codes for both countries and languages

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -31,13 +31,16 @@ which must define the following values in its header:
 *   `address` is the workshop's address (including details like the
     room number). The address should be all on one line.
 
-*   `country` must be a hyphenated title-cased country name like
-    'United-States'.  This is used to look up flags for display in the
-    main web site.
+*   `country` must be a two-letter ISO-3166 code for the country in
+    which the workshop is going to take place, such as 'fr' (for
+    France) or 'nz' (for New Zealand) - see [Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
+    for a complete list.
 
 *   `language` is the language that will be used in the workshop.
-    It must be a
-    [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+    It must be an [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+    Note that two-letter codes mean different things for countries
+    and languages: 'ar' is Arabic when used for a language, but
+    Argentina when used for a country.
 
 *   `latlng` is the latitude and longitude of the workshop site (so we
     can put a pin on our map).  You can use

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 ---
 layout: workshop
 root: .
-venue: FIXME      # brief name of host site
-address: FIXME    # street address of home location
-country: FIXME    # country (hyphenated if need be, like 'United-Kingdom')
-language: FIXME   # language code like 'en' or 'fr'
+venue: FIXME      # brief name of host site _without address_ (e.g., "Euphoric State University")
+address: FIXME    # street address of workshop
+country: FIXME    # country (two-letter ISO code - see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
+language: FIXME   # language (two-letter ISO code - see above)
 latlng: FIXME     # fractional latitude and longitude like 41.7901128,-87.6007318
 humandate: FIXME  # use the format 'Feb 17-18, 2020' (without the quotes)
 humantime: FIXME  # use the format '9:00 am - 4:30 pm' (without the quotes)
@@ -12,9 +12,9 @@ startdate: FIXME  # use YYYY-MM-DD format like 2015-01-01
 enddate: FIXME    # use YYYY-MM-DD format like 2015-01-02
 instructor: FIXME # list of names like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: FIXME     # list of names like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
-contact: FIXME    # contact email address for workshop organizer
-etherpad:   # optional (insert the URL for your Etherpad if you're using one)
-eventbrite: # optional (delete this if not used, otherwise uncomment and provide 1234567890AB key for Eventbrite registration)
+contact: FIXME    # contact email address for workshop organizer, such as 'grace@hopper.org' (without the quotes)
+etherpad:         # optional (insert the URL for your Etherpad if you're using one)
+eventbrite:       # optional (delete this if not used, otherwise uncomment and provide 1234567890AB key for Eventbrite registration)
 ---
 <!--
   HEADER

--- a/index.html
+++ b/index.html
@@ -1,20 +1,20 @@
 ---
 layout: workshop
 root: .
-venue: FIXME      # brief name of host site _without address_ (e.g., "Euphoric State University")
-address: FIXME    # street address of workshop
-country: FIXME    # country (two-letter ISO code - see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
-language: FIXME   # language (two-letter ISO code - see above)
-latlng: FIXME     # fractional latitude and longitude like 41.7901128,-87.6007318
-humandate: FIXME  # use the format 'Feb 17-18, 2020' (without the quotes)
-humantime: FIXME  # use the format '9:00 am - 4:30 pm' (without the quotes)
+venue: FIXME      # brief name of host site without address (e.g., "Euphoric State University")
+address: FIXME    # street address of workshop (e.g., "123 Forth Street, Blimingen, Euphoria")
+country: FIXME    # country (two-letter ISO code such as "fr" - see https://en.wikipedia.org/wiki/ISO_3166-1)
+language: FIXME   # language (two-letter ISO code such as "fr" - see https://en.wikipedia.org/wiki/ISO_639-1)
+latlng: FIXME     # fractional latitude and longitude (e.g., 41.7901128,-87.6007318)
+humandate: FIXME  # human-readable date (e.g., 'Feb 17-18, 2020' without the quotes)
+humantime: FIXME  # human-readable time (e.g., '9:00 am - 4:30 pm' without the quotes)
 startdate: FIXME  # use YYYY-MM-DD format like 2015-01-01
 enddate: FIXME    # use YYYY-MM-DD format like 2015-01-02
 instructor: FIXME # list of names like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: FIXME     # list of names like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 contact: FIXME    # contact email address for workshop organizer, such as 'grace@hopper.org' (without the quotes)
 etherpad:         # optional (insert the URL for your Etherpad if you're using one)
-eventbrite:       # optional (delete this if not used, otherwise uncomment and provide 1234567890AB key for Eventbrite registration)
+eventbrite:       # optional (insert the alphanumeric key for Eventbrite registration, e.g., 1234567890AB)
 ---
 <!--
   HEADER

--- a/tools/check.py
+++ b/tools/check.py
@@ -49,6 +49,30 @@ USAGE = 'Usage: "python check.py" or "python check.py path/to/index.html"\n'
 # is 'Arabic' as a language but 'Argentina' as a country.
 
 ISO_COUNTRY = [
+    'ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'an', 'ao', 'aq', 'ar', 'as',
+    'at', 'au', 'aw', 'ax', 'az', 'ba', 'bb', 'bd', 'be', 'bf', 'bg', 'bh',
+    'bi', 'bj', 'bm', 'bn', 'bo', 'br', 'bs', 'bt', 'bv', 'bw', 'by', 'bz',
+    'ca', 'cc', 'cd', 'cf', 'cg', 'ch', 'ci', 'ck', 'cl', 'cm', 'cn', 'co',
+    'cr', 'cu', 'cv', 'cx', 'cy', 'cz', 'de', 'dj', 'dk', 'dm', 'do', 'dz',
+    'ec', 'ee', 'eg', 'eh', 'er', 'es', 'et', 'eu', 'fi', 'fj', 'fk', 'fm',
+    'fo', 'fr', 'ga', 'gb', 'gd', 'ge', 'gf', 'gg', 'gh', 'gi', 'gl', 'gm',
+    'gn', 'gp', 'gq', 'gr', 'gs', 'gt', 'gu', 'gw', 'gy', 'hk', 'hm', 'hn',
+    'hr', 'ht', 'hu', 'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is',
+    'it', 'je', 'jm', 'jo', 'jp', 'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp',
+    'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc', 'li', 'lk', 'lr', 'ls', 'lt',
+    'lu', 'lv', 'ly', 'ma', 'mc', 'md', 'me', 'mg', 'mh', 'mk', 'ml', 'mm',
+    'mn', 'mo', 'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my',
+    'mz', 'na', 'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu',
+    'nz', 'om', 'pa', 'pe', 'pf', 'pg', 'ph', 'pk', 'pl', 'pm', 'pn', 'pr',
+    'ps', 'pt', 'pw', 'py', 'qa', 're', 'ro', 'rs', 'ru', 'rw', 'sa', 'sb',
+    'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so',
+    'sr', 'st', 'sv', 'sy', 'sz', 'tc', 'td', 'tf', 'tg', 'th', 'tj', 'tk',
+    'tl', 'tm', 'tn', 'to', 'tr', 'tt', 'tv', 'tw', 'tz', 'ua', 'ug', 'um',
+    'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn', 'vu', 'wf', 'ws',
+    'ye', 'yt', 'za', 'zm', 'zw'
+]
+
+ISO_LANGUAGE = [
     'aa', 'ab', 'ae', 'af', 'ak', 'am', 'an', 'ar', 'as', 'av', 'ay', 'az',
     'ba', 'be', 'bg', 'bh', 'bi', 'bm', 'bn', 'bo', 'br', 'bs', 'ca', 'ce',
     'ch', 'co', 'cr', 'cs', 'cu', 'cv', 'cy', 'da', 'de', 'dv', 'dz', 'ee',
@@ -61,25 +85,6 @@ ISO_COUNTRY = [
     'mt', 'my', 'na', 'nb', 'nd', 'ne', 'ng', 'nl', 'nn', 'no', 'nr', 'nv',
     'ny', 'oc', 'oj', 'om', 'or', 'os', 'pa', 'pi', 'pl', 'ps', 'pt', 'qu',
     'rm', 'rn', 'ro', 'ru', 'rw', 'sa', 'sc', 'sd', 'se', 'sg', 'si', 'sk',
-    'sl', 'sm', 'sn', 'so', 'sq', 'sr', 'ss', 'st', 'su', 'sv', 'sw', 'ta',
-    'te', 'tg', 'th', 'ti', 'tk', 'tl', 'tn', 'to', 'tr', 'ts', 'tt', 'tw',
-    'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'wo', 'xh', 'yi',
-    'yo', 'za', 'zh', 'zu'
-]
-
-ISO_LANGUAGE = [
-    'aa', 'ab', 'ae', 'af', 'ak', 'am', 'an', 'ar', 'as', 'av', 'ay', 'az',
-    'ba', 'be', 'bg', 'bi', 'bm', 'bn', 'bo', 'br', 'bs', 'ca', 'ce', 'ch',
-    'co', 'cr', 'cs', 'cu', 'cv', 'cy', 'da', 'de', 'dv', 'dz', 'ee', 'el',
-    'en', 'eo', 'es', 'et', 'eu', 'fa', 'ff', 'fi', 'fj', 'fo', 'fr', 'fy',
-    'ga', 'gd', 'gl', 'gn', 'gu', 'gv', 'ha', 'he', 'hi', 'ho', 'hr', 'ht',
-    'hu', 'hy', 'hz', 'ia', 'id', 'ie', 'ig', 'ii', 'ik', 'io', 'is', 'it',
-    'iu', 'ja', 'jv', 'ka', 'kg', 'ki', 'kj', 'kk', 'kl', 'km', 'kn', 'ko',
-    'kr', 'ks', 'ku', 'kv', 'kw', 'ky', 'la', 'lb', 'lg', 'li', 'ln', 'lo',
-    'lt', 'lu', 'lv', 'mg', 'mh', 'mi', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt',
-    'my', 'na', 'nb', 'nd', 'ne', 'ng', 'nl', 'nn', 'no', 'nr', 'nv', 'ny',
-    'oc', 'oj', 'om', 'or', 'os', 'pa', 'pi', 'pl', 'ps', 'pt', 'qu', 'rm',
-    'rn', 'ro', 'ru', 'rw', 'sa', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sk',
     'sl', 'sm', 'sn', 'so', 'sq', 'sr', 'ss', 'st', 'su', 'sv', 'sw', 'ta',
     'te', 'tg', 'th', 'ti', 'tk', 'tl', 'tn', 'to', 'tr', 'ts', 'tt', 'tw',
     'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'wo', 'xh', 'yi',

--- a/tools/check.py
+++ b/tools/check.py
@@ -45,75 +45,10 @@ DEFAULT_CONTACT_EMAIL = 'admin@software-carpentry.org'
 
 USAGE = 'Usage: "python check.py" or "python check.py path/to/index.html"\n'
 
-COUNTRIES = [
-    'Abkhazia', 'Afghanistan', 'Aland', 'Albania', 'Algeria',
-    'American-Samoa', 'Andorra', 'Angola', 'Anguilla',
-    'Antarctica', 'Antigua-and-Barbuda', 'Argentina', 'Armenia',
-    'Aruba', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas',
-    'Bahrain', 'Bangladesh', 'Barbados', 'Basque-Country',
-    'Belarus', 'Belgium', 'Belize', 'Benin', 'Bermuda', 'Bhutan',
-    'Bolivia', 'Bosnia-and-Herzegovina', 'Botswana', 'Brazil',
-    'British-Antarctic-Territory', 'British-Virgin-Islands',
-    'Brunei', 'Bulgaria', 'Burkina-Faso', 'Burundi', 'Cambodia',
-    'Cameroon', 'Canada', 'Canary-Islands', 'Cape-Verde',
-    'Cayman-Islands', 'Central-African-Republic', 'Chad',
-    'Chile', 'China', 'Christmas-Island',
-    'Cocos-Keeling-Islands', 'Colombia', 'Commonwealth',
-    'Comoros', 'Cook-Islands', 'Costa-Rica', 'Cote-dIvoire',
-    'Croatia', 'Cuba', 'Curacao', 'Cyprus', 'Czech-Republic',
-    'Democratic-Republic-of-the-Congo', 'Denmark', 'Djibouti',
-    'Dominica', 'Dominican-Republic', 'East-Timor', 'Ecuador',
-    'Egypt', 'El-Salvador', 'England', 'Equatorial-Guinea',
-    'Eritrea', 'Estonia', 'Ethiopia', 'European-Union',
-    'Falkland-Islands', 'Faroes', 'Fiji', 'Finland', 'France',
-    'French-Polynesia', 'French-Southern-Territories', 'Gabon',
-    'Gambia', 'Georgia', 'Germany', 'Ghana', 'Gibraltar',
-    'GoSquared', 'Greece', 'Greenland', 'Grenada', 'Guam',
-    'Guatemala', 'Guernsey', 'Guinea-Bissau', 'Guinea', 'Guyana',
-    'Haiti', 'Honduras', 'Hong-Kong', 'Hungary', 'Iceland',
-    'India', 'Indonesia', 'Iran', 'Iraq', 'Ireland',
-    'Isle-of-Man', 'Israel', 'Italy', 'Jamaica', 'Japan',
-    'Jersey', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
-    'Kosovo', 'Kuwait', 'Kyrgyzstan', 'Laos', 'Latvia',
-    'Lebanon', 'Lesotho', 'Liberia', 'Libya', 'Liechtenstein',
-    'Lithuania', 'Luxembourg', 'Macau', 'Macedonia',
-    'Madagascar', 'Malawi', 'Malaysia', 'Maldives', 'Mali',
-    'Malta', 'Mars', 'Marshall-Islands', 'Martinique',
-    'Mauritania', 'Mauritius', 'Mayotte', 'Mexico', 'Micronesia',
-    'Moldova', 'Monaco', 'Mongolia', 'Montenegro', 'Montserrat',
-    'Morocco', 'Mozambique', 'Myanmar', 'NATO',
-    'Nagorno-Karabakh', 'Namibia', 'Nauru', 'Nepal',
-    'Netherlands-Antilles', 'Netherlands', 'New-Caledonia',
-    'New-Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'Niue',
-    'Norfolk-Island', 'North-Korea', 'Northern-Cyprus',
-    'Northern-Mariana-Islands', 'Norway', 'Olympics', 'Oman',
-    'Pakistan', 'Palau', 'Palestine', 'Panama',
-    'Papua-New-Guinea', 'Paraguay', 'Peru', 'Philippines',
-    'Pitcairn-Islands', 'Poland', 'Portugal', 'Puerto-Rico',
-    'Qatar', 'Red-Cross', 'Republic-of-the-Congo', 'Romania',
-    'Russia', 'Rwanda', 'Saint-Barthelemy', 'Saint-Helena',
-    'Saint-Kitts-and-Nevis', 'Saint-Lucia', 'Saint-Martin',
-    'Saint-Vincent-and-the-Grenadines', 'Samoa', 'San-Marino',
-    'Sao-Tome-and-Principe', 'Saudi-Arabia', 'Scotland',
-    'Senegal', 'Serbia', 'Seychelles', 'Sierra-Leone',
-    'Singapore', 'Slovakia', 'Slovenia', 'Solomon-Islands',
-    'Somalia', 'Somaliland', 'South-Africa',
-    'South-Georgia-and-the-South-Sandwich-Islands',
-    'South-Korea', 'South-Ossetia', 'South-Sudan', 'Spain',
-    'Sri-Lanka', 'Sudan', 'Suriname', 'Swaziland', 'Sweden',
-    'Switzerland', 'Syria', 'Taiwan', 'Tajikistan', 'Tanzania',
-    'Thailand', 'Togo', 'Tokelau', 'Tonga',
-    'Trinidad-and-Tobago', 'Tunisia', 'Turkey', 'Turkmenistan',
-    'Turks-and-Caicos-Islands', 'Tuvalu', 'US-Virgin-Islands',
-    'Uganda', 'Ukraine', 'United-Arab-Emirates',
-    'United-Kingdom', 'United-Nations', 'United-States',
-    'Unknown', 'Uruguay', 'Uzbekistan', 'Vanuatu',
-    'Vatican-City', 'Venezuela', 'Vietnam', 'Wales',
-    'Wallis-And-Futuna', 'Western-Sahara', 'Yemen', 'Zambia',
-    'Zimbabwe'
-]
+# Country and language codes.  Note that codes mean different things: 'ar'
+# is 'Arabic' as a language but 'Argentina' as a country.
 
-LANGUAGES = [
+ISO_COUNTRY = [
     'aa', 'ab', 'ae', 'af', 'ak', 'am', 'an', 'ar', 'as', 'av', 'ay', 'az',
     'ba', 'be', 'bg', 'bh', 'bi', 'bm', 'bn', 'bo', 'br', 'bs', 'ca', 'ce',
     'ch', 'co', 'cr', 'cs', 'cu', 'cv', 'cy', 'da', 'de', 'dv', 'dz', 'ee',
@@ -126,6 +61,25 @@ LANGUAGES = [
     'mt', 'my', 'na', 'nb', 'nd', 'ne', 'ng', 'nl', 'nn', 'no', 'nr', 'nv',
     'ny', 'oc', 'oj', 'om', 'or', 'os', 'pa', 'pi', 'pl', 'ps', 'pt', 'qu',
     'rm', 'rn', 'ro', 'ru', 'rw', 'sa', 'sc', 'sd', 'se', 'sg', 'si', 'sk',
+    'sl', 'sm', 'sn', 'so', 'sq', 'sr', 'ss', 'st', 'su', 'sv', 'sw', 'ta',
+    'te', 'tg', 'th', 'ti', 'tk', 'tl', 'tn', 'to', 'tr', 'ts', 'tt', 'tw',
+    'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'wo', 'xh', 'yi',
+    'yo', 'za', 'zh', 'zu'
+]
+
+ISO_LANGUAGE = [
+    'aa', 'ab', 'ae', 'af', 'ak', 'am', 'an', 'ar', 'as', 'av', 'ay', 'az',
+    'ba', 'be', 'bg', 'bi', 'bm', 'bn', 'bo', 'br', 'bs', 'ca', 'ce', 'ch',
+    'co', 'cr', 'cs', 'cu', 'cv', 'cy', 'da', 'de', 'dv', 'dz', 'ee', 'el',
+    'en', 'eo', 'es', 'et', 'eu', 'fa', 'ff', 'fi', 'fj', 'fo', 'fr', 'fy',
+    'ga', 'gd', 'gl', 'gn', 'gu', 'gv', 'ha', 'he', 'hi', 'ho', 'hr', 'ht',
+    'hu', 'hy', 'hz', 'ia', 'id', 'ie', 'ig', 'ii', 'ik', 'io', 'is', 'it',
+    'iu', 'ja', 'jv', 'ka', 'kg', 'ki', 'kj', 'kk', 'kl', 'km', 'kn', 'ko',
+    'kr', 'ks', 'ku', 'kv', 'kw', 'ky', 'la', 'lb', 'lg', 'li', 'ln', 'lo',
+    'lt', 'lu', 'lv', 'mg', 'mh', 'mi', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt',
+    'my', 'na', 'nb', 'nd', 'ne', 'ng', 'nl', 'nn', 'no', 'nr', 'nv', 'ny',
+    'oc', 'oj', 'om', 'or', 'os', 'pa', 'pi', 'pl', 'ps', 'pt', 'qu', 'rm',
+    'rn', 'ro', 'ru', 'rw', 'sa', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sk',
     'sl', 'sm', 'sn', 'so', 'sq', 'sr', 'ss', 'st', 'su', 'sv', 'sw', 'ta',
     'te', 'tg', 'th', 'ti', 'tk', 'tl', 'tn', 'to', 'tr', 'ts', 'tt', 'tw',
     'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'wo', 'xh', 'yi',
@@ -170,18 +124,16 @@ def check_root(root):
 
 @look_for_fixme
 def check_country(country):
-    '''"country" must be a hyphenated full country name from the list
-    embedded in this script.'''
+    '''"country" must be an ISO-3166 two-letter code.'''
 
-    return country in COUNTRIES
+    return country in ISO_COUNTRY
 
 
 @look_for_fixme
 def check_language(language):
-    '''"language" must be one of the two-letter ISO 639-1 language codes
-    embedded in this script.'''
+    '''"language" must be an ISO-639 two-letter code.'''
 
-    return language in LANGUAGES
+    return language in ISO_LANGUAGE
 
 
 @look_for_fixme
@@ -301,12 +253,13 @@ def check_pass(value):
 HANDLERS = {
     'layout':     (True, check_layout, 'layout isn\'t "workshop"'),
     'root':       (True, check_root, 'root can only be "."'),
-    'country':    (True, check_country,
-                   'country invalid: must use full hyphenated name from: ' +
-                   ' '.join(COUNTRIES)),
 
+    'country':    (True, check_country,
+                   'country invalid: must use two-letter ISO code from ' +
+                   ', '.join(ISO_COUNTRY)),
     'language' :  (False,  check_language,
-                   'language invalid: must be a ISO 639-1 code'),
+                   'language invalid: must use two-letter ISO code from ' +
+                   ', '.join(ISO_LANGUAGE)),
 
     'humandate':  (True, check_humandate,
                    'humandate invalid. Please use three-letter months like ' +
@@ -337,6 +290,7 @@ HANDLERS = {
 
     'eventbrite': (False, check_eventbrite, 'Eventbrite key appears invalid.'),
     'etherpad':   (False, check_etherpad, 'Etherpad URL appears invalid.'),
+
     'venue':      (False, check_pass, 'venue name not specified'),
     'address':    (False, check_pass, 'address not specified')
 }


### PR DESCRIPTION
This uses ISO codes for countries and languages instead of Hyphenated-Names for countries.
