### PR TITLE
clearer cut-off before running website locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ $ jekyll server -d _site
 
 and going to http://localhost:4000.
 
+## That's it
+---------------------------------------------------------
+ The following steps are only necesary if you want to run the website locally on your computer.
+
 ## Installing Software
 
 In order to preview the workshop website locally on your computer,


### PR DESCRIPTION
I added a clearer distinction between the sections of actually creating and checking the website and the steps of running the website locally because the last part is not needed by most people. At our training, a lot of people got confused during those steps even tho they are not necessary.
