### PR TITLE
Fit typical Eventbrite registration w/o scrollbar activating

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@ eventbrite: # optional (delete this if not used, otherwise uncomment and provide
   src="https://www.eventbrite.com/tickets-external?eid={{page.eventbrite}}&ref=etckt"
   frameborder="0"
   width="100%"
-  height="206px"
+  height="248px"
   scrolling="auto">
 </iframe>
 {% endif %}


### PR DESCRIPTION
Previous value of "206" fit to the Eventbrite box for full registration ("Add to Waitlist"), but didn't fit the box for _open_ registration (with a larger "Register" button).
