### PR TITLE
Add "lowercase" to language and country checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@ layout: workshop
 root: .
 venue: FIXME      # brief name of host site without address (e.g., "Euphoric State University")
 address: FIXME    # street address of workshop (e.g., "123 Forth Street, Blimingen, Euphoria")
-country: FIXME    # country (two-letter ISO code such as "fr" - see https://en.wikipedia.org/wiki/ISO_3166-1)
-language: FIXME   # language (two-letter ISO code such as "fr" - see https://en.wikipedia.org/wiki/ISO_639-1)
+country: FIXME    # country (lowercase two-letter ISO code such as "fr" - see https://en.wikipedia.org/wiki/ISO_3166-1)
+language: FIXME   # language (lowercase two-letter ISO code such as "fr" - see https://en.wikipedia.org/wiki/ISO_639-1)
 latlng: FIXME     # fractional latitude and longitude (e.g., "41.7901128,-87.6007318"; you can use http://www.latlong.net/)
 humandate: FIXME  # human-readable date (e.g., "Feb 17-18, 2020")
 humantime: FIXME  # human-readable time (e.g., "9:00 am - 4:30 pm")

--- a/tools/check.py
+++ b/tools/check.py
@@ -129,14 +129,14 @@ def check_root(root):
 
 @look_for_fixme
 def check_country(country):
-    '''"country" must be an ISO-3166 two-letter code.'''
+    '''"country" must be a lowercase ISO-3166 two-letter code.'''
 
     return country in ISO_COUNTRY
 
 
 @look_for_fixme
 def check_language(language):
-    '''"language" must be an ISO-639 two-letter code.'''
+    '''"language" must be a lowercase ISO-639 two-letter code.'''
 
     return language in ISO_LANGUAGE
 
@@ -260,11 +260,11 @@ HANDLERS = {
     'root':       (True, check_root, 'root can only be "."'),
 
     'country':    (True, check_country,
-                   'country invalid: must use two-letter ISO code from ' +
-                   ', '.join(ISO_COUNTRY)),
-    'language' :  (False,  check_language,
-                   'language invalid: must use two-letter ISO code from ' +
-                   ', '.join(ISO_LANGUAGE)),
+                   'country invalid: must use lowercase two-letter ISO code ' +
+                   'from ' + ', '.join(ISO_COUNTRY)),
+    'language':   (False,  check_language,
+                   'language invalid: must use lowercase two-letter ISO code' +
+                   ' from ' + ', '.join(ISO_LANGUAGE)),
 
     'humandate':  (True, check_humandate,
                    'humandate invalid. Please use three-letter months like ' +


### PR DESCRIPTION
This is to ensure people will use lowercase ISO codes ("pl", "fr",
etc.)

This change is pushed upstream from https://github.com/swcarpentry/amy/pull/503.
