### PR TITLE
Putting all metadata in meta headers

### DIFF
--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -10,9 +10,22 @@
     <title>Software Carpentry: {{ page.venue }}</title>
     {% include header.html %}
     <meta name="venue" content="{{page.venue}}" />
-    <meta name="date" content="{{page.humandate}}" />
+    <meta name="address" content="{{page.address}}" />
+    <meta name="country" content="{{page.country}}" />
+    <meta name="language" content="{{page.language}}" />
+    <meta name="latlng" content="{{page.latlng}}" />
+    <meta name="humandate" content="{{page.humandate}}" />
     <meta name="startdate" content="{{page.startdate}}" />
     <meta name="enddate" content="{{page.enddate}}" />
+    <meta name="instructor" content="{{page.instructor}}" />
+    <meta name="helper" content="{{page.helper}}" />
+    <meta name="contact" content="{{page.contact}}" />
+    {% if page.etherpad %}
+    <meta name="etherpad" content="{{page.etherpad}}" />
+    {% endif %}
+    {% if page.eventbrite %}
+    <meta name="eventbrite" content="{{page.eventbrite}}" />
+    {% endif %}
     {% if page.redirect %}
     <meta http-equiv="refresh" content="0; url={{page.redirect}}" />
     {% endif %}


### PR DESCRIPTION
This enables AMY to get the metadata it needs about a workshop from the `<head>` of a workshop website's `index.html`, which in turn means that people can build those pages however they want if they don't want (or aren't allowed) to use GitHub Pages.
