### PR TITLE
Added new FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -181,3 +181,7 @@
     If you're using a browser plugin like [HTTPS Everywhere](https://www.eff.org/https-everywhere)
     you will need to disable it for your workshop's site.
     We are presently (January 2015) working to get HTTPS working properly on our website.
+
+*   *Help, my github.io website is not updating!*
+
+    Ensure that strings in the index.html header are enclosed in quotations `"`. Special characters such as `"&"` may render correctly on your local machine but cause rendering to fail (silently?) on GitHub.


### PR DESCRIPTION
Added new debugging problem to the FAQ. Special characters in header strings that are not surrounded with quotes, will render correctly on a local preview but fail silently on GitHub.
