### PR TITLE
Capitalize Bash in installation instructions for Mac

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,10 +383,10 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
     <div class="col-md-4">
       <h4 id="shell-macosx">Mac OS X</h4>
       <p>
-        The default shell in all versions of Mac OS X is bash, so no
-        need to install anything.  You access bash from the Terminal
+        The default shell in all versions of Mac OS X is Bash, so no
+        need to install anything.  You access Bash from the Terminal
         (found in
-        <code>/Applications/Utilities</code>).  You may want to keep
+        <code>/Applications/Utilities</code>). You may want to keep
         Terminal in your dock for this workshop.
       </p>
     </div>
@@ -467,7 +467,7 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
       <h4 id="editor-windows">Windows</h4>
       <p>
         nano is a basic editor and the default that instructors use in the workshop.
-        To install it, 
+        To install it,
         download the <a href="{{site.swc_installer}}">Software Carpentry Windows installer</a>
         and double click on the file to run it.
         <strong>This installer requires an active internet connection.</strong>


### PR DESCRIPTION
The installation instructions for Mac OS X had "bash", change this to "Bash".
