### PR TITLE
Added note on installing Jekyll with specific version of Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ you must install the software described below.
      the default Redcarpet, because Kramdown handles Markdown
      inside HTML blocks.
 
+    Note: You may need to specify the version of gem to use for installation (if you have multiple versions of Ruby installed). For example for version 2.0 you could use:
+
+     ~~~
+     $ gem2.0 install github-pages
+     ~~~
+
+
 2.  The Python YAML module
 
     If you are using the Anaconda Python distribution, you probably


### PR DESCRIPTION
I ran into issues installing github-pages with gem because I had two versions of Ruby installed (1.9 and 2.0). In my case, using

```
$ gem install github-pages
```

kept failing even though I had version 2.0 installed.  To solve it I had to specify to install it with version 2.0, 

```
$ gem2.0 install github-pages
```

I think it would be helpful to provide a note about this in the README.md in case others encounter similar issues.
