### PR TITLE
index.html: Comment out setup/ link to make installation-tests opt-in

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -100,7 +100,12 @@ so that they show what you're actually planning to teach and when.
 You should delete the pieces of the `Setup` section
 related to software you will not be using in your workshop,
 so that learners don't spend time installing software they don't need.
-After you edit the `Setup` section, you should edit the installation test script.
+
+## Setup: Installation tests
+
+If you intend to use the installation-test scripts,
+uncomment the paragraph linking to `setup/index.html` in `index.html`
+and edit `setup/swc-installation-test-2.py` as described below.
 
 `swc-installation-test-1.py` is pretty simple, and just checks that
 the students have a recent enough version of Python installed that

--- a/index.html
+++ b/index.html
@@ -589,11 +589,13 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
       </ol>
     </div>
   </div>
+<!--
   <p>
   Once you are done installing the software listed above,
   please go to <a href="setup/index.html">this page</a>,
   which has instructions on how to test that everything was installed correctly.
   </p>
+-->
 </div> <!-- End of 'Python' section. -->
 
 <div id="r"> <!-- Start of 'R' section. -->


### PR DESCRIPTION
Sometimes instructors forget to customize their CHECKS, but learners
still follow this link and run the stock checks, resulting in a bunch
of confusing errors about missing packages that the [learner](https://github.com/swcarpentry/workshop-template/issues/136)
[doesn't](https://github.com/swcarpentry/workshop-template/issues/180) [actually](https://github.com/swcarpentry/workshop-template/issues/181) [need](https://github.com/swcarpentry/workshop-template/issues/258).  Instead of expecting
instructors to edit CHECKS or remove the setup/ reference from
index.html (a default that is right for nobody), this commit comments
that setup/ reference out (a default that is right for folks who don't
want installation-checks).  Instructors who _do_ want installation
checks now need to do two things (uncomment the setup/ reference and
update CHECKS), but with both steps listed in CUSTOMIZATION they are
more likely to get that right.

Spun off from [this thread](http://lists.software-carpentry.org/pipermail/maintainers_lists.software-carpentry.org/2016-January/000113.html).
