### PR TITLE
Define "standard" downloads and provide a script to update

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -133,6 +133,10 @@ you have no Emacs experience and don't want to be responsible for
 students who show up with Emacs as their only editor), you can comment
 out that particular `or_dependency`.
 
+## Home Page: Downloads
+
+You should edit the `Downloads` section to list content you will be using in your workshop.
+
 ## Updating the repository
 
 If for some reason,

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -135,7 +135,22 @@ out that particular `or_dependency`.
 
 ## Home Page: Downloads
 
-You should edit the `Downloads` section to list content you will be using in your workshop.
+You should edit the `Downloads` section to list content you will be
+using in your workshop.  If you don't want to do that by hand,
+`tools/update-downloads.py` script can automatically populate the
+download section with downloads required for your lesson set.  Call it
+with:
+
+~~~
+$ ./tools/update-downloads.py lessons.json index.html
+~~~
+
+after creating a `lessons.json` file.  For a description of the
+`lessons.json` syntax, run:
+
+~~~
+$ ./tools/update-downloads.py --help
+~~~
 
 ## Updating the repository
 

--- a/index.html
+++ b/index.html
@@ -775,6 +775,10 @@ Software Carpentry staff may need to know in your email.</h4>
   <li><a href="https://swcarpentry.github.io/shell-novice/shell-novice-data.zip"><code>shell-novice-data.zip</code></a></li>
   <!-- for swcarpentry/python-novice-inflammation -->
   <li><a href="https://swcarpentry.github.io/python-novice-inflammation/python-novice-inflammation-data.zip"><code>python-novice-inflammation-data.zip</code></a></li>
+  <!-- for swcarpentry/r-novice-inflammation -->
+<!--
+  <li><a href="https://swcarpentry.github.io/r-novice-inflammation/r-novice-inflammation-data.zip"><code>r-novice-inflammation-data.zip</code></a></li>
+-->
   <!-- for swcarpentry/sql-novice-survey -->
   <li><a href="https://files.software-carpentry.org/survey.db"><code>survey.db</code></a></li>
   <li><a href="https://files.software-carpentry.org/survey.sql"><code>survey.sql</code></a></li>

--- a/index.html
+++ b/index.html
@@ -771,4 +771,6 @@ Software Carpentry staff may need to know in your email.</h4>
 </p>
 
 <ul class="downloads">
+  <!-- for swcarpentry/shell-novice -->
+  <li><a href="https://swcarpentry.github.io/shell-novice/shell-novice-data.zip"><code>shell-novice-data.zip</code></a></li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -119,11 +119,13 @@ Software Carpentry staff may need to know in your email.</h4>
   Modify the block below if there are any special requirements.
 -->
 <p id="requirements">
-  <strong>Requirements:</strong> Participants must bring a laptop with a
-  Mac, Linux, or Windows operating sytem (not a tablet, Chromebook, etc.) that they have administrative privileges
-  on. They should have a few specific software packages installed (listed
-  <a href="#setup">below</a>). They are also required to abide by
-  Software Carpentry's
+  <strong>Requirements:</strong> Participants must bring a laptop with
+  a Mac, Linux, or Windows operating sytem (not a tablet, Chromebook,
+  etc.) that they have administrative privileges on. They should have
+  a few specific software packages installed (listed
+  <a href="#setup">here</a>) and example data-sets downloaded
+  (listed <a href="#downloads">here</a>). They are also required to
+  abide by Software Carpentry's
   <a href="{{site.swc_site}}/conduct.html">Code of Conduct</a>.
 </p>
 
@@ -751,3 +753,22 @@ Software Carpentry staff may need to know in your email.</h4>
   </ol>
 </div>
 -->
+
+<!--
+  DOWNLOADS
+
+  Links to learner downloads (e.g. datasets needed by lessons).
+  Delete/modify as needed to match the lessons you are covering.
+-->
+
+<h2 id="downloads">Downloads</h2>
+
+<p>
+  The following downloads and data-sets will be used during the
+  workshop.  Please download and save them in a location you can find
+  for the workshop (for example, your desktop or your downloads
+  directory).
+</p>
+
+<ul class="downloads">
+</ul>

--- a/index.html
+++ b/index.html
@@ -775,4 +775,7 @@ Software Carpentry staff may need to know in your email.</h4>
   <li><a href="https://swcarpentry.github.io/shell-novice/shell-novice-data.zip"><code>shell-novice-data.zip</code></a></li>
   <!-- for swcarpentry/python-novice-inflammation -->
   <li><a href="https://swcarpentry.github.io/python-novice-inflammation/python-novice-inflammation-data.zip"><code>python-novice-inflammation-data.zip</code></a></li>
+  <!-- for swcarpentry/sql-novice-survey -->
+  <li><a href="https://files.software-carpentry.org/survey.db"><code>survey.db</code></a></li>
+  <li><a href="https://files.software-carpentry.org/survey.sql"><code>survey.sql</code></a></li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -773,4 +773,6 @@ Software Carpentry staff may need to know in your email.</h4>
 <ul class="downloads">
   <!-- for swcarpentry/shell-novice -->
   <li><a href="https://swcarpentry.github.io/shell-novice/shell-novice-data.zip"><code>shell-novice-data.zip</code></a></li>
+  <!-- for swcarpentry/python-novice-inflammation -->
+  <li><a href="https://swcarpentry.github.io/python-novice-inflammation/python-novice-inflammation-data.zip"><code>python-novice-inflammation-data.zip</code></a></li>
 </ul>

--- a/tools/update-downloads.py
+++ b/tools/update-downloads.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+"""Update the downloads section in index.html.
+
+Based on the lessons.json file like:
+
+{
+  "lessons": {
+    "shell": {
+      "downloads": "https://raw.githubusercontent.com/swcarpentry/shell-novice/v5.4/requirements.json"
+    },
+    "git": {
+      "downloads": "https://raw.githubusercontent.com/swcarpentry/git-novice/v5.3/requirements.json"
+    },
+    "python": {
+      "downloads": "https://raw.githubusercontent.com/swcarpentry/python-novice-inflammation/v5.4/requirements.json"
+    },
+    "sql": {
+      "downloads": "https://raw.githubusercontent.com/swcarpentry/sql-novice-survey/v5.7/requirements.json"
+    }
+  }
+}
+"""
+
+from __future__ import print_function  # for Python 2.6 compatibility
+
+import json as _json
+import logging as _logging
+import sys as _sys
+try:  # Python 3.x
+    import urllib.parse as _urllib_parse
+    import urllib.request as _urllib_request
+except ImportError:  # Python 2.x
+    import urlparse as _urllib_parse
+    import urllib2 as _urllib_request  # for urlopen()
+
+
+_LOG = _logging.getLogger(__name__)
+
+
+def _get_json(url):
+    response = _urllib_request.urlopen(url)  # not context manager in Python 2
+    info = response.info()
+    response_bytes = response.read()
+    if hasattr(info, 'get_content_charset'):
+        # Python 3, info is email.message.Message
+        charset = info.get_content_charset('UTF-8')
+    else:  # Python 2, info is mimetools.Message
+        charset = info.getparam('charset') or 'UTF-8'
+    response.close()
+    json = response_bytes.decode(charset)
+    return _json.loads(json)
+
+
+def get_downloads(config):
+    links = []
+    with open(config, 'r') as f:
+        setup = _json.load(f)
+    for lesson, lesson_config in sorted(setup.get('lessons', {}).items()):
+        downloads_url = lesson_config.get('downloads')
+        if downloads_url:
+            _LOG.debug('get downloads for {} from {}'.format(
+                lesson, downloads_url))
+            downloads = _get_json(url=downloads_url)
+            links.extend(downloads)
+    return links
+
+
+def replace_downloads(path, downloads):
+    lines = []
+    with open(path, 'r') as f:
+        in_downloads = False
+        for line in f.readlines():
+            if in_downloads:
+                if line.startswith('</ul>'):
+                    lines.append(line)
+                    in_downloads = False
+            else:
+                lines.append(line)
+            if line.startswith('<ul class="downloads">'):
+                if f.newlines:
+                    newline = f.newlines[0]
+                else:
+                    newline = '\n'
+                in_downloads = True
+                for download in downloads:
+                    parsed = _urllib_parse.urlparse(download)
+                    basename = parsed.path.rstrip('/').split('/')[-1]
+                    lines.append(
+                        '  <li><a href="{0}"><code>{1}</code></a></li>{2}'
+                        .format(download, basename, newline))
+        html = f.read()
+    with open(path, 'w') as f:
+        for line in lines:
+            f.write(line)
+
+
+if __name__ == '__main__':
+    import optparse as _optparse
+
+    _LOG.addHandler(_logging.StreamHandler())
+
+    parser = _optparse.OptionParser(usage='%prog [options] CONFIG HTML')
+    epilog = __doc__
+    parser.format_epilog = lambda formatter: '\n' + epilog
+    parser.add_option(
+        '-v', '--verbose', action='store_true',
+        help=('print additional information to help troubleshoot '
+              'download updates'))
+    options, args = parser.parse_args()
+
+    if len(args) != 2:
+        parser.print_usage(file=_sys.stderr)
+        _sys.exit(1)
+
+    config, html = args
+
+    downloads = get_downloads(config=config)
+    replace_downloads(path=html, downloads=downloads)


### PR DESCRIPTION
Details in the commit message.  The from the last commit is based on
the changes in wking/swc-setup-installation-test#9, and the lesson
JSON files in both PRs are compatible.

If/when lesson maintainers start providing the download-declaring JSON
files, we can provide an example lessons.json file in this repository.

Fixes #276.
Previous discussion in
