### PR TITLE
Fixes `startdate` and `enddate` comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@ language: FIXME   # language (lowercase two-letter ISO code such as "fr" - see h
 latlng: FIXME     # fractional latitude and longitude (e.g., "41.7901128,-87.6007318"; you can use http://www.latlong.net/)
 humandate: FIXME  # human-readable date (e.g., "Feb 17-18, 2020")
 humantime: FIXME  # human-readable time (e.g., "9:00 am - 4:30 pm")
-startdate: FIXME  # use YYYY-MM-DD format like "2015-01-01"
-enddate: FIXME    # use YYYY-MM-DD format like" 2015-01-02"
+startdate: FIXME  # use YYYY-MM-DD format like 2015-01-01
+enddate: FIXME    # use YYYY-MM-DD format like 2015-01-02
 instructor: FIXME # list of names like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: FIXME     # list of names like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 contact: FIXME    # contact email address for workshop organizer, such as "grace@hopper.org"


### PR DESCRIPTION
Use YYYY-MM-DD instead of "YYYY-MM-DD", which offends `tools/check.py`
