### PR TITLE
Move survey links outside of agenda

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,11 +149,16 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
 -->
 <h2 id="schedule">Schedule</h2>
 
+<!-- DO NOT EDIT SURVEY LINKS -->
+<em>Surveys</em>
+Please be sure to complete these surveys before and after the workshop.
+<a href='{{ site.swc_pre_survey }}{{ site.github.project_title }}'>Pre-workshop Survey</a>
+<a href='{{ site.swc_post_survey }}{{ site.github.project_title }}'>Post-workshop Survey</a>
+
 <div class="row">
   <div class="col-md-6">
     <h3>Day 1</h3>
     <table class="table table-striped">
-      <tr> <td>Arrival</td>  <td><a href='{{ site.swc_pre_survey }}{{ site.github.project_title }}'>Pre-workshop Survey</a></td> </tr>
       <tr> <td>09:00</td>  <td>Automating tasks with the Unix shell</td> </tr>
       <tr> <td>10:30</td> <td>Coffee</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
@@ -171,7 +176,6 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
       <tr> <td>13:00</td>  <td>Managing data with SQL</td> </tr>
       <tr> <td>14:30</td>  <td>Coffee</td> </tr>
       <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
-      <tr> <td>Dismissal</td>  <td><a href='{{ site.swc_post_survey }}{{ site.github.project_title }}'>Post-workshop Survey</a></td> </tr>
     </table>
   </div>
 </div>


### PR DESCRIPTION
When people edit the workshop agenda they often end up removing the links to the surveys and then need SWC staff to re-send them.  Links are now moved outside the agenda.
