### PR TITLE
Added section for Make setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -690,6 +690,90 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
     Instructors will provide a workaround for it if needed.</strong></p>
 </div> <!-- End of 'SQLite' section. -->
 
+<div id="make"> <!-- Start of 'Make' section. -->
+  <h3>Make</h3>
+
+  <p>
+    Make is a tool which can run commands to read files, process these
+    files in some way, and write out the processed files. Make can be
+    used to compile source code into executable programs or libraries;
+    run analysis scripts on raw data files to get data files that
+    summarize the raw data; run visualisation scripts on data files to
+    produce plots; and to parse and combine text files and plots to
+    create papers. 
+    <a href="http://www.gnu.org/software/make/">GNU Make</a> is a
+    free, fast, well-documented, and very popular Make
+    implementation. 
+  </p>
+  <div class="row">
+    <div class="col-md-4">
+      <h4 id="make-windows">Windows</h4>
+      <p>
+        The <a href="{{site.swc_github}}/windows-installer">Software
+        Carpentry Windows Installer</a> installs Make. 
+        If you used the installer to configure nano, you don't need to
+        run it again.
+      </p>
+    </div>
+    <div class="col-md-4">
+      <h4 id="make-macosx">Mac OS X</h4>
+      <p>
+        <strong>For OS X 10.9 and higher</strong>:
+      </p>
+      <ul>
+	<li>Open a terminal window</li>
+	<li>Type <code>xcode-select --install</code></li>
+	<li>
+	  A window will appear asking "Would you like to install
+	  the tools now?"
+	</li>
+	<li>Click Install</li>
+	<li>
+	  A window will appear saying that "The software was
+	  installed."
+	</li>
+	<li>Click Done</li>
+      </ul>
+      <p>
+        <strong>For older versions of OS X (10.5-10.8)</strong>:
+      </p>
+      <p>
+	If you do not already have access to make from within your
+        shell, you will need to install XCode (which is free, but over
+        a gigabyte to download):
+      </p>
+      <ul>
+        <li>Go
+          to <a href="https://developer.apple.com/downloads/">developer.apple.com</a>
+        </li>
+        <li>Click on Sign in (if you have an Apple ID) or on Create Apple ID</li>
+        <li>In Search Downloads, enter XCode</li>
+        <li>Select a suitable version of XCode for your version of OS X</li>
+      </ul>
+      <p>
+	Once XCode has installed:
+      </p>
+      <ul>
+	<li>Click on Applications</li>
+	<li>Click on XCode</li>
+	<li>Select on XCode&rarr;Preferences...</li>
+	<li>Click on Downloads</li>
+	<li>Select on Command Line Tools</li>
+	<li>Click on Install</li>
+      </ul>
+    </div>
+    <div class="col-md-4">
+      <h4 id="make-linux">Linux</h4>
+      <p>
+        If Make is not already available on your machine you can try to 
+        install it via your distro's package manager. For
+        Debian/Ubuntu run <code>sudo apt-get install make</code> and
+        for Fedora run <code>sudo yum install make</code>.
+      </p>
+    </div>
+  </div>
+</div> <!-- End of 'Make' section. -->
+
 <!--
   Uncomment this section if you are using our virtual machine.
 

--- a/index.html
+++ b/index.html
@@ -709,7 +709,7 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
     <div class="col-md-4">
       <h4 id="make-windows">Windows</h4>
       <p>
-        The <a href="{{site.swc_github}}/windows-installer">Software
+        The <a href="{{site.swc_installer}}">Software
         Carpentry Windows Installer</a> installs Make. 
         If you used the installer to configure nano, you don't need to
         run it again.

--- a/index.html
+++ b/index.html
@@ -738,7 +738,7 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
         <strong>For older versions of OS X (10.5-10.8)</strong>:
       </p>
       <p>
-	If you do not already have access to make from within your
+	If you do not already have access to Make from within your
         shell, you will need to install XCode (which is free, but over
         a gigabyte to download):
       </p>

--- a/index.html
+++ b/index.html
@@ -721,24 +721,24 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
         <strong>For OS X 10.9 and higher</strong>:
       </p>
       <ul>
-	<li>Open a terminal window</li>
-	<li>Type <code>xcode-select --install</code></li>
-	<li>
-	  A window will appear asking "Would you like to install
-	  the tools now?"
-	</li>
-	<li>Click Install</li>
-	<li>
-	  A window will appear saying that "The software was
-	  installed."
-	</li>
-	<li>Click Done</li>
+        <li>Open a terminal window</li>
+        <li>Type <code>xcode-select --install</code></li>
+        <li>
+          A window will appear asking "Would you like to install
+          the tools now?"
+        </li>
+        <li>Click Install</li>
+        <li>
+          A window will appear saying that "The software was
+          installed."
+        </li>
+        <li>Click Done</li>
       </ul>
       <p>
         <strong>For older versions of OS X (10.5-10.8)</strong>:
       </p>
       <p>
-	If you do not already have access to Make from within your
+        If you do not already have access to Make from within your
         shell, you will need to install XCode (which is free, but over
         a gigabyte to download):
       </p>
@@ -751,15 +751,15 @@ eventbrite:       # optional (insert the alphanumeric key for Eventbrite registr
         <li>Select a suitable version of XCode for your version of OS X</li>
       </ul>
       <p>
-	Once XCode has installed:
+        Once XCode has installed:
       </p>
       <ul>
-	<li>Click on Applications</li>
-	<li>Click on XCode</li>
-	<li>Select on XCode&rarr;Preferences...</li>
-	<li>Click on Downloads</li>
-	<li>Select on Command Line Tools</li>
-	<li>Click on Install</li>
+        <li>Click on Applications</li>
+        <li>Click on XCode</li>
+        <li>Select on XCode&rarr;Preferences...</li>
+        <li>Click on Downloads</li>
+        <li>Select on Command Line Tools</li>
+        <li>Click on Install</li>
       </ul>
     </div>
     <div class="col-md-4">


### PR DESCRIPTION
Ported across from pull request (https://github.com/swcarpentry/bc/pull/533) with updates to reflect changes in SWC Windows Installer which now installs "make".

The Mac OS instructions need validated as I don't have access to a Mac.
