### PR TITLE
advising removal of all lines above --- at start

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 
 <!-- See instructions in the comments below for how to edit specific sections of this workshop template. -->
-
+<!-- remove everything above and including this line to have the page render properly -->
 ---
 layout: workshop      # DON'T CHANGE THIS.
 root: .               # DON'T CHANGE THIS.


### PR DESCRIPTION
Setting up a new workshop page I found it will not be generated properly unless everything above --- is removed, and so --- is located on the first line.
