### PR TITLE
FAQ: Motivate the 'YYYY-MM-DD-site' pattern

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -16,6 +16,14 @@
     Because any particular user can only have one fork of a repository,
     but instructors frequently need to work on several workshops at once.
 
+*   *Why does the workshop repository name have to follow the `YYYY-MM-DD-site` pattern?*
+
+    This makes it easy for coordinators to track workshops in
+    spreadsheets for instructor training.
+    There are [plans to move that coordination into AMY][amy-training],
+    but until that happens this pattern makes it easy to sort workshops
+    by date without requiring an additional start-date column.
+
 *   *Why use the `gh-pages` branch instead of `master`?
 
     Because [GitHub automatically publishes `gh-pages`](https://help.github.com/articles/creating-project-pages-manually/)
@@ -183,3 +191,5 @@
 *   *Help, my github.io website is not updating!*
 
     Ensure that strings in the index.html header are enclosed in quotations `"`. Special characters such as `"&"` may render correctly on your local machine but cause rendering to fail (silently?) on GitHub.
+
+[amy-training]: https://github.com/numfocus/gsoc/blob/0f76b09e1147d9dc5d55c4fb822639740fdaf58f/2016/ideas-list-swc.md#manage-workflow-for-instructor-training


### PR DESCRIPTION
Documenting discussion from #310, especially:

On Tue, Mar 22, 2016 at 10:02:38AM -0700, Greg Wilson [wrote](https://github.com/swcarpentry/workshop-template/issues/310#issuecomment-199908347):

> Various spreadsheets where information about trainees is recorded,
> and workshop websites on disk - the former will (hopefully) migrate
> into AMY this summer, after which the need will be less pressing,
> but it'll still be easier to find/track things if we stick to
> uniform naming.
