### PR TITLE
Adapt Anaconda installer tab completion example to Python 3.

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,7 +617,7 @@ Software Carpentry staff may need to know in your email.</h4>
           Open a terminal window.
         </li>
         <li>
-          Type <pre>bash Anaconda-</pre> and then press
+          Type <pre>bash Anaconda3-</pre> and then press
           tab. The name of the file you just downloaded should
           appear.
         </li>


### PR DESCRIPTION
Current Python 3 installer is called Anaconda3-4.0.0-Linux-x86_64.sh
and 'bash Anaconda-' would not autocomplete.
