### PR TITLE
Instructions create a github account in workshop preparation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,6 +465,15 @@ Software Carpentry staff may need to know in your email.</h4>
     web browser (current versions of Chrome, Firefox or Safari,
     or Internet Explorer version 9 or above).
   </p>
+  <p>
+    You will need an account at <a href="https://github.com/">github.com</a>
+    for parts of the git lesson. Basic Github accounts are free. We encourage
+    you to create a Github account if you don't have one already.
+    Please consider what personal information you'd like to reveal. For
+    example, you may want to review these
+    <a href="https://help.github.com/articles/keeping-your-email-address-private/">instructions
+    for keeping your email address private</a> provided at Github.
+  </p>
 
   <div class="row">
     <div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -467,12 +467,12 @@ Software Carpentry staff may need to know in your email.</h4>
   </p>
   <p>
     You will need an account at <a href="https://github.com/">github.com</a>
-    for parts of the git lesson. Basic Github accounts are free. We encourage
-    you to create a Github account if you don't have one already.
+    for parts of the Git lesson. Basic GitHub accounts are free. We encourage
+    you to create a GitHub account if you don't have one already.
     Please consider what personal information you'd like to reveal. For
     example, you may want to review these
     <a href="https://help.github.com/articles/keeping-your-email-address-private/">instructions
-    for keeping your email address private</a> provided at Github.
+    for keeping your email address private</a> provided at GitHub.
   </p>
 
   <div class="row">


### PR DESCRIPTION
This should enable participants who don't yet have a github account
in their own time, so they're less likely to end up with "yet another
account at some website".

Inspired by https://github.com/swcarpentry/git-novice/issues/267#issuecomment-216702727 and may go some way to address that issue.
