### PR TITLE
Include instructions for setting "HOME" on Windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,6 +425,18 @@ Software Carpentry staff may need to know in your email.</h4>
             <li>Click on "Finish".</li>
           </ol>
         </li>
+        <li>
+          If your "HOME" environment variable is not set (or you don't know what this is):
+          <ol>
+            <li>Open command prompt (Open Start Menu then type <code>cmd</code> and press [Enter])</li>
+            <li>
+              Type the following line into the command prompt window exactly as shown:
+              <p><code>setx HOME "%USERPROFILE%"</code></p>
+            </li>
+            <li>Press [Enter], you should see <code>SUCCESS: Specified value was saved.</code></li>
+            <li>Quit command prompt by typing <code>exit</code> then pressing [Enter]</li>
+          </ol>
+        </li>
       </ol>
       <p>This will provide you with both Git and Bash in the Git Bash program.</p>
     </div>


### PR DESCRIPTION
Current Git instructions leave vanilla Windows users with a Git Bash that starts in the Program Files\Git install location, this also means that when they run the SWC Installer Git Bash won't pick up 'nano'. We need to get them to set a HOME environment variable to the value of %USERPROFILE%, this is possible via 'setx' (should 'just work' on Win 7+). The PR adds instructions for doing this to the template.
