### PR TITLE
Updated Git install instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,40 +386,35 @@ Software Carpentry staff may need to know in your email.</h4>
         <li>Download the Git for Windows <a href="https://git-for-windows.github.io/">installer</a>.</li>
         <li>Run the installer and follow the steps bellow:
           <ol>
-            <!-- Git 2.6.1 Setup -->
-            <!-- Welcome to the Git Setup Wizard -->
-            <li>Click on "Next".</li>
+            <!-- Git 2.8.2 Setup -->
             <!-- Information -->
             <li>Click on "Next".</li>
-            <!-- Select Destination Location -->
-            <li>Click on "Next".</li>
             <!-- Select Components -->
-            <li>Click on "Next".</li>
-            <!-- Select Start Menu Folder -->
             <li>Click on "Next".</li>
             <!-- Adjusting your PATH environment -->
             <li>
               <strong>
-                Select "Use Git from the Windows Command Prompt" and click on "Next".
+                Keep "Use Git from the Windows Command Prompt" selected and click on "Next".
               </strong>
                 If you forgot to do this programs that you need for the workshop will not work properly.
                 If this happens rerun the installer and select the appropriate option.
             </li>
+            <!-- Choosing the SSH executable -->
+            <li>Click on "Next".</li>
             <!-- Configuring the line ending conversions -->
             <li>
-              Click on "Next".
               <strong>
-                Keep "Checkout Windows-style, commit Unix-style line endings" selected.
+                Keep "Checkout Windows-style, commit Unix-style line endings" selected and click on "Next".
               </strong>
             </li>
             <!-- Configuring the terminal emulator to use with Git Bash -->
             <li>
               <strong>
-                Select "Use Windows' default console window" and click on "Next".
+                Keep "Use Windows' default console window" selected and click on "Next".
               </strong>
             </li>
             <!-- Configuring experimental performance tweaks -->
-            <li>Click on "Next".</li>
+            <li>Click on "Install".</li>
             <!-- Installing -->
             <!-- Completing the Git Setup Wizard -->
             <li>Click on "Finish".</li>


### PR DESCRIPTION
Previous instructions had too many 'next's for current installer (2.8.2)
