### PR TITLE
fix swc_github_io versus swc_github

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ repository: <USERNAME>/<PROJECT>
 # Sites.
 amy_site: "https://amy.software-carpentry.org/workshops"
 dc_site: "https://datacarpentry.org"
-swc_github: "https://github.com/swcarpentry"
+swc_github_io: "https://github.com/swcarpentry"
 swc_site: "https://software-carpentry.org"
 template_repo: "https://github.com/swcarpentry/styles"
 example_repo: "https://github.com/swcarpentry/lesson-example"

--- a/_config.yml
+++ b/_config.yml
@@ -25,8 +25,9 @@ repository: <USERNAME>/<PROJECT>
 # Sites.
 amy_site: "https://amy.software-carpentry.org/workshops"
 dc_site: "https://datacarpentry.org"
-swc_github_io: "https://github.com/swcarpentry"
+swc_github: "https://github.com/swcarpentry"
 swc_site: "https://software-carpentry.org"
+swc_pages: "https://swcarpentry.github.io"
 template_repo: "https://github.com/swcarpentry/styles"
 example_repo: "https://github.com/swcarpentry/lesson-example"
 example_site: "https://swcarpentry.github.com/lesson-example"

--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@ Software Carpentry staff may need to know in your email.</h4>
       <li>Looping over files</li>
       <li>Creating and running shell scripts</li>
       <li>Finding things</li>
-      <li><a href="{{site.swc_github_io}}/shell-novice/reference/">Reference...</a></li>
+      <li><a href="{{site.swc_pages}}/shell-novice/reference/">Reference...</a></li>
     </ul>
   </div>
   <div class="col-md-6">
@@ -268,7 +268,7 @@ Software Carpentry staff may need to know in your email.</h4>
       <li>Loops and conditionals</li>
       <li>Defensive programming</li>
       <li>Using Python from the command line</li>
-      <li><a href="{{site.swc_github_io}}/python-novice-inflammation/reference/">Reference...</a></li>
+      <li><a href="{{site.swc_pages}}/python-novice-inflammation/reference/">Reference...</a></li>
     </ul>
   </div>
   <!--
@@ -280,7 +280,7 @@ Software Carpentry staff may need to know in your email.</h4>
       <li>Creating and using functions</li>
       <li>Loops and conditionals</li>
       <li>Using R from the command line</li>
-      <li><a href="{{site.swc_github_io}}/r-novice-inflammation/reference/">Reference...</a></li>
+      <li><a href="{{site.swc_pages}}/r-novice-inflammation/reference/">Reference...</a></li>
     </ul>
   </div>
   -->
@@ -293,7 +293,7 @@ Software Carpentry staff may need to know in your email.</h4>
       <li>Creating and using functions</li>
       <li>Loops and conditionals</li>
       <li>Defensive programming</li>
-      <li><a href="{{site.swc_github_io}}/matlab-novice-inflammation/reference/">Reference...</a></li>
+      <li><a href="{{site.swc_pages}}/matlab-novice-inflammation/reference/">Reference...</a></li>
      </ul>
    </div>
    -->
@@ -311,7 +311,7 @@ Software Carpentry staff may need to know in your email.</h4>
       <li>Resolving conflicts</li>
       <li>Open licenses</li>
       <li>Where to host work, and why</li>
-      <li><a href="{{site.swc_github_io}}/git-novice/reference/">Reference...</a></li>
+      <li><a href="{{site.swc_pages}}/git-novice/reference/">Reference...</a></li>
     </ul>
   </div>
   <div class="col-md-6">
@@ -325,7 +325,7 @@ Software Carpentry staff may need to know in your email.</h4>
       <li>Combining information from multiple tables using <code>join</code></li>
       <li>Creating, modifying, and deleting data</li>
       <li>Programming with databases</li>
-      <li><a href="{{site.swc_github_io}}/sql-novice-survey/reference/">Reference...</a></li>
+      <li><a href="{{site.swc_pages}}/sql-novice-survey/reference/">Reference...</a></li>
     </ul>
   </div>
 </div>
@@ -354,7 +354,7 @@ Software Carpentry staff may need to know in your email.</h4>
 <p>
   We maintain a list of common issues that occur during installation as a reference for instructors
   that may be useful on the
-  <a href = "https://github.com/swcarpentry/workshop-template/wiki/Configuration-Problems-and-Solutions">Configuration Problems and Solutions wiki page</a>.
+  <a href = "{{site.swc_github}}/workshop-template/wiki/Configuration-Problems-and-Solutions">Configuration Problems and Solutions wiki page</a>.
 </p>
 
 <div id="shell"> <!-- Start of 'shell' section. -->


### PR DESCRIPTION
index.html uses `swc_github_io`, _config.yml uses `swc_github`. This is I think what caused links in the final workshop website to be wrong.
