### PR TITLE
add note that users should install R as administrator on Windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,6 +675,10 @@ Software Carpentry staff may need to know in your email.</h4>
         from <a href="http://cran.r-project.org/index.html">CRAN</a>.
         Also, please install the
         <a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
+        Note that if you have separate user and admin accounts, you should run the 
+        installers as administrator (right-click on .exe file and select "Run as 
+        administrator" instead of double-clicking). Otherwise problems may occur later, 
+        for example when installing R packages.
       </p>
     </div>
     <div class="col-md-4">


### PR DESCRIPTION
Add note to installation instructions mentioning that users should install R as administrator on Windows. Otherwise, if it is installed from a user account by simply double-clicking the .exe, it appears to install fine but there may be problems later, for example when installing R packages. See discussion on Software Carpentry "discuss" mailing list on September 13, 2016: http://lists.software-carpentry.org/pipermail/discuss/2016-September/004722.html
