### PR TITLE
Add link to SWC Windows Installer. Fixes #343.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ example_site: "https://swcarpentry.github.com/lesson-example"
 workshop_repo: "https://github.com/swcarpentry/workshop-template"
 workshop_site: "https://swcarpentry.github.io/workshop-template"
 training_site: "https://swcarpentry.github.io/instructor-training"
+swc_installer: "https://github.com/swcarpentry/windows-installer/releases/download/v0.3/SWCarpentryInstaller.exe"
 
 # Surveys.
 pre_survey: "https://www.surveymonkey.com/r/swc_pre_workshop_v1?workshop_id="


### PR DESCRIPTION
I received a very surprising email this morning. One of the attendees for my workshop tomorrow couldn't download the SWC Windows Installer. Is there anyway to notify all the instructors that created a workshop website using this template without the link?
