### PR TITLE
Add link to template for Google Calendar event

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,19 @@ and the administrator will contact you if we need any extra information.</h4>
 {% endif %}
 
 <!--
+  DATE
+
+  This block displays the date and links to Google Calendar.
+-->
+{% if page.humandate %}
+<p id="when">
+  <strong>When:</strong>
+  {{page.humandate}}.
+  <a href="//calendar.google.com/calendar/render?action=TEMPLATE&text={% if page.carpentry == "swc" %}Software{% elsif page.carpentry == "dc" %}Data{% endif %} Carpentry Workshop&dates={{ page.startdate | replace: "-", "" }}/{{ page.enddate | replace: "-", "" }}&trp=false&sprop&sprop=name:&sf=true&output=xml&location={{ page.address }}&details={% if page.carpentry == "swc" %}Software{% elsif page.carpentry == "dc" %}Data{% endif %} Carpentry Workshop at {{ page.venue }}">Add to your Google Calendar.</a>
+</p>
+{% endif %}
+
+<!--
   SPECIAL REQUIREMENTS
 
   Modify the block below if there are any special requirements.


### PR DESCRIPTION
Cover #326 following https://github.com/swcarpentry/workshop-template/issues/326#issuecomment-254171009.

# Screenshot of link result

![screencapture-calendar-google-calendar-render-1481560529849](https://cloud.githubusercontent.com/assets/1506457/21107381/640792c0-c089-11e6-9a22-d86f405b63c9.png)

# Limitations

Start and end time of the workshop. The `humantime` that we use is difficult to parse **on [Liquid](http://shopify.github.io/liquid/)** so that we can use on the template.

Non-registered user can add the event to their calendar. This is a first world problem!

# Future work

We maybe want to review the YAML metadata to make the Google Calendar event more accurate. cc @k8hertweck 