### PR TITLE
Changing language under general information

### DIFF
--- a/index.html
+++ b/index.html
@@ -588,8 +588,8 @@ and the administrator will contact you if we need any extra information.</h4>
 
   <p>
     <a href="http://python.org">Python</a> is a popular language for
-    scientific computing, and great for general-purpose programming as
-    well.  Installing all of its scientific packages individually can be
+    research computing, and great for general-purpose programming as
+    well.  Installing all of its research packages individually can be
     a bit difficult, so we recommend
     <a href="https://www.continuum.io/anaconda">Anaconda</a>,
     an all-in-one installer.

--- a/index.html
+++ b/index.html
@@ -62,9 +62,9 @@ and the administrator will contact you if we need any extra information.</h4>
 -->
 <p>
   <a href="{{site.swc_site}}">Software Carpentry</a>
-  teaches researchers how to get their work done
+  aims to help researchers get their work done
   in less time and with less pain
-  by using basic research computing skills.
+  by teaching them basic research computing skills.
   This hands-on workshop will cover basic concepts and tools,
   including program design, version control, data management,
   and task automation.

--- a/index.html
+++ b/index.html
@@ -62,8 +62,9 @@ and the administrator will contact you if we need any extra information.</h4>
 -->
 <p>
   <a href="{{site.swc_site}}">Software Carpentry</a>
-  teaches researchers the basics of writing and maintaining code
-  to help them get more done in less time with less pain.
+  teaches researchers how to get their work done
+  in less time and with less pain
+  by using basic research computing skills.
   This hands-on workshop will cover basic concepts and tools,
   including program design, version control, data management,
   and task automation.

--- a/index.html
+++ b/index.html
@@ -61,14 +61,14 @@ and the administrator will contact you if we need any extra information.</h4>
   the pitch.
 -->
 <p>
-  <a href="{{site.swc_site}}">Software Carpentry</a>'s mission
-  is to help scientists and engineers get more research done in less
-  time and with less pain by teaching them basic lab skills for
-  scientific computing.  This hands-on workshop will cover basic
-  concepts and tools, including program design, version control, data
-  management, and task automation.  Participants will be encouraged to
-  help one another and to apply what they have learned to their own
-  research problems.
+  <a href="{{site.swc_site}}">Software Carpentry</a>
+  teaches researchers the basics of writing and maintaining code
+  to help them get more done in less time with less pain.
+  This hands-on workshop will cover basic concepts and tools,
+  including program design, version control, data management,
+  and task automation.
+  Participants will be encouraged to help one another
+  and to apply what they have learned to their own research problems.
 </p>
 <p align="center">
   <em>


### PR DESCRIPTION
This pull request covers issue #367 created by @sclayton29.

## Original text

> **Software Carpentry's mission is to help scientists and engineers get more research done in less time and with less pain by teaching them basic lab skills for scientific computing.** This hands-on workshop will cover basic concepts and tools, including program design, version control, data management, and task automation. Participants will be encouraged to help one another and to apply what they have learned to their own research problems.

## Sarah's suggestion

> **Software Carpentry teaches researchers the basics of writing and maintaining code to help them get more done in less time with less pain.** This hands-on workshop will cover basic concepts and tools, including program design, version control, data management, and task automation. Participants will be encouraged to help one another and to apply what they have learned to their own research problems.

## Text on this pull request

> **Software Carpentry teaches researchers how to get their work done in less time and with less pain by using basic research computing skills.** This hands-on workshop will cover basic concepts and tools, including program design, version control, data management, and task automation. Participants will be encouraged to help one another and to apply what they have learned to their own research problems.

The consensus on #367 is that we should replace "scientists and engineers" with "researchers". @lexnederbragt asked to avoid limiting the description of Software Carpentry to " basics of writing and maintaining code" with is valid. The version on this pull request tries to accommodate @sclayton29's and @lexnederbragt's ideas. **I had to replace the "Software Carpentry's mission is" because only the Steering Committee can vote to change the mission statement.**