### PR TITLE
Clarify Python installation instructions for Linux

### DIFF
--- a/index.html
+++ b/index.html
@@ -634,28 +634,32 @@ and the administrator will contact you if we need any extra information.</h4>
       <h4 id="python-linux">Linux</h4>
       <ol>
         <li>Open <a href="http://continuum.io/downloads">http://continuum.io/downloads</a> with your web browser.</li>
-        <li>Download the Python 3 installer for Linux.</li>
-        <li>Install Python 3 using all of the defaults for installation.
-        (Installation requires using the shell. If you aren't
-        comfortable doing the installation yourself
-        stop here and request help at the workshop.)</li>
+        <li>Download the Python 3 installer for Linux.<br>
+          (Installation requires using the shell. If you aren't
+           comfortable doing the installation yourself
+           stop here and request help at the workshop.)
+        </li>
         <li>
           Open a terminal window.
         </li>
         <li>
           Type <pre>bash Anaconda3-</pre> and then press
           tab. The name of the file you just downloaded should
-          appear.
+          appear. If it does not, navigate to the folder where you
+          downloaded the file, for example with:
+          <pre>cd Downloads</pre>
+          Then, try again.
         </li>
         <li>
-          Press enter. You will follow the text-only prompts.  When
-          there is a colon at the bottom of the screen press the down
-          arrow to move down through the text. Type <code>yes</code> and
+          Press enter. You will follow the text-only prompts. To move through
+          the text, press the space key. Type <code>yes</code> and
           press enter to approve the license. Press enter to approve the
           default location for the files. Type <code>yes</code> and
           press enter to prepend Anaconda to your <code>PATH</code>
           (this makes the Anaconda distribution the default Python).
         </li>
+        <li>
+          Close the terminal window.
       </ol>
     </div>
   </div>


### PR DESCRIPTION
See #290.

The changes and the rationale behind them:
* Remove the line "Install Python 3 using all of the defaults for installation", because describing *how* to install it is what is done in the next steps (also: "using all of the defaults" is not correct, the last answer should be "yes" to prepend Anaconda to the `PATH`, but the default is "no")
* Add a remark that possibly a `cd Downloads` or similar is necessary to find the downloaded file
* Replace "When there is a colon at the bottom of the screen press the down arrow to move down through the text." by "To move through the text, press the space key." -- the details of what you see depend on your pager (e.g. with `more` you see `--More--` and not a colon) and the down arrow does not work with `more` (space works with both `more` and `less`).
* Add "Close the terminal window." in the end. If the learners leave the terminal window open, the `PATH` change is not applied and they can therefore not start python or the Jupyter notebook. The installer mentions this at the end, but this can be a major stumbling block so I think it is better to make this explicit in the instructions.