### PR TITLE
Replace Git Bash with Cygwin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: python
+python:
+  - "3.2"
+  - "3.3"
+  - "3.4"
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+# command to run tests
+before_script:
+  - "awk -i inplace 'FNR == 4 {print \"carpentry: swc\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 5 {print \"venue: Foo\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 6 {print \"address: Room 123\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 7 {print \"country: us\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 8 {print \"language: en\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 9 {print \"latlng: 0,0\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 10 {print \"humandate: Jan 01-02, 2020\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 11 {print \"humantime: 9:00 am - 4:30 pm\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 12 {print \"startdate: 2020-01-01\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 13 {print \"enddate: 2020-01-01\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 14 {print \"instructor: [Foo]\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 15 {print \"helper: [Foo]\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 16 {print \"contact: [foo@bar.com]\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 17 {print \"collaborative_notes: http://foo.bar\"} {print}' index.html"
+  - "awk -i inplace 'FNR == 18 {print \"eventbrite: 1234567890AB\"} {print}' index.html"
+script:
+  - python bin/workshop_check.py .
+branches:
+  only:
+    - gh-pages


### PR DESCRIPTION
# Summary

Some instructors reported issues with the [Windows Installer](https://github.com/swcarpentry/windows-installer) in the past. This pull request (1) replace the Windows Installer with a PowerShell script, (2) replace instructions to install [Git for Windows](https://git-for-windows.github.io/), also know as Git Bash, with instructions to run the PowerShell script, (3) drop instructions to run the Windows Installer, and (4) remove the section about text editor from the setup. The PowerShell script will install [Cygwin](https://cygwin.com/).

This pull request can be tested at http://rgaiacs.github.io/swc-workshop-template/.

# Why PowerShell script?

[PowerShell](https://en.wikipedia.org/wiki/PowerShell) is a task automation and configuration management framework from Microsoft, **like Bash for GNU/Linux**. Using it will avoid the need to install other programs and with it reduce "bug" surface area.

# Why replace Git for Windows with Cygwin?

Cygwin has `bash`, `man`, `git`. `nano`, `make`, and `sqlite3` when Git for Windows only has `bash` and `git`. By using Cygwing, our learners only need to install one program. **Another great addition is that we will have `man`.**

#  Why remove the section about text editor?

We will have `nano` in Windows, Mac, and GNU/Linux. We can avoid the cognitive overflow from our learners when going over the setup instructions alone.

# Extra benefits

`nano` will not overflow the shell making the history inaccessible when scrolling.

# Any drawback

No.

# Any block to be merge

Yes. Need proofreading and more test.

- [X] Windows 10 (done by @rgaiacs)
- [ ] Windows 8
- [x] Windows 7

http://rgaiacs.github.io/swc-workshop-template/ can be used to proofreading and test.