### PR TITLE
Add reference to 'lc' for Library Carpentry in README and _config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ and styling them according to the instructions give in
 If you do this,
 you *must* also edit `_config.yml` to set these three values:
 
-1.  `carpentry` is either "dc" (for Data Carpentry) or "swc" (for Software Carpentry).
-    This determines which logos are loaded.
+1.  `carpentry` is either "dc" (for Data Carpentry), "swc" (for Software Carpentry),
+    or "lc" (for Library Carpentry). This determines which logos are loaded.
 
 2.  `title` is the title of your workshop (typically the venue and date).
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # Values for this workshop.
 #------------------------------------------------------------
 
-# Which carpentry is this ("swc" or "dc")?
+# Which carpentry is this ("swc", "dc", or "lc")?
 carpentry: "swc"
 
 # Overall title for pages.


### PR DESCRIPTION
Related to #393. This adds an explicit set of references to `lc` as the code for Library Carpentry in Jekyll's configuration and the README.