### PR TITLE
Fix for #414: removed mailto link from the accessibility paragraph to avoid repetition

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@ and our administrator may contact you if we need any extra information.</h4>
   large-print handouts are available if needed by notifying the
   organizers in advance.  If we can help making learning easier for
   you (e.g. sign-language interpreters, lactation facilities) please
-  <a href="mailto:{{page.contact}}">get in touch</a> and we will
+  get in touch (using contact details below) and we will
   attempt to provide them.
 </p>
 


### PR DESCRIPTION
Fix for #414: removed mailto link from the accessibility paragraph and pointed to contact details, which immediately follow in the paragraph below. 
