### PR TITLE
Switch yum for dnf in Fedora install instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@ and our administrator may contact you if we need any extra information.</h4>
         If Git is not already available on your machine you can try to
         install it via your distro's package manager. For Debian/Ubuntu run
         <code>sudo apt-get install git</code> and for Fedora run
-        <code>sudo yum install git</code>.
+        <code>sudo dnf install git</code>.
       </p>
     </div>
   </div>
@@ -651,7 +651,7 @@ and our administrator may contact you if we need any extra information.</h4>
         from <a href="http://cran.r-project.org/index.html">CRAN</a>. Or
         you can use your package manager (e.g. for Debian/Ubuntu
         run <code>sudo apt-get install r-base</code> and for Fedora run
-        <code>sudo yum install R</code>).  Also, please install the
+        <code>sudo dnf install R</code>).  Also, please install the
         <a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
       </p>
     </div>


### PR DESCRIPTION
`yum` was replaced by `dnf` on Fedora several years ago. Just updating things to stay somewhat current.