### PR TITLE
Changed Python download links to Anaconda.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,7 +526,7 @@ and our administrator may contact you if we need any extra information.</h4>
     research computing, and great for general-purpose programming as
     well.  Installing all of its research packages individually can be
     a bit difficult, so we recommend
-    <a href="https://www.continuum.io/anaconda">Anaconda</a>,
+    <a href="https://www.anaconda.com/distribution/">Anaconda</a>,
     an all-in-one installer.
   </p>
 
@@ -551,7 +551,7 @@ and our administrator may contact you if we need any extra information.</h4>
       <h4 id="python-windows">Windows</h4>
       <a href="https://www.youtube.com/watch?v=xxQ0mzZ8UvA">Video Tutorial</a>
       <ol>
-        <li>Open <a href="http://continuum.io/downloads">http://continuum.io/downloads</a> with your web browser.</li>
+        <li>Open <a href="https://www.anaconda.com/download/#windows">https://www.anaconda.com/download/#windows</a> with your web browser.</li>
         <li>Download the Python 3 installer for Windows.</li>
         <li>Install Python 3 using all of the defaults for installation <em>except</em> make sure to check <strong>Make Anaconda the default Python</strong>.</li>
       </ol>
@@ -560,7 +560,7 @@ and our administrator may contact you if we need any extra information.</h4>
       <h4 id="python-macosx">Mac OS X</h4>
       <a href="https://www.youtube.com/watch?v=TcSAln46u9U">Video Tutorial</a>
       <ol>
-        <li>Open <a href="http://continuum.io/downloads">http://continuum.io/downloads</a> with your web browser.</li>
+        <li>Open <a href="https://www.anaconda.com/download/#macos">https://www.anaconda.com/download/#macos</a> with your web browser.</li>
         <li>Download the Python 3 installer for OS X.</li>
         <li>Install Python 3 using all of the defaults for installation.</li>
       </ol>
@@ -568,7 +568,7 @@ and our administrator may contact you if we need any extra information.</h4>
     <div class="col-md-4">
       <h4 id="python-linux">Linux</h4>
       <ol>
-        <li>Open <a href="http://continuum.io/downloads">http://continuum.io/downloads</a> with your web browser.</li>
+        <li>Open <a href="https://www.anaconda.com/download/#linux">https://www.anaconda.com/download/#linux</a> with your web browser.</li>
         <li>Download the Python 3 installer for Linux.<br>
           (The installation requires using the shell. If you aren't
            comfortable doing the installation yourself


### PR DESCRIPTION
Continuum changed their organization name to Anaconda, and changed
their URL from continuum.io to anaconda.com.

This was originally proposed in Issue #437 