### PR TITLE
Add current year to copyright of workshop footer

### DIFF
--- a/_includes/workshop_footer.html
+++ b/_includes/workshop_footer.html
@@ -5,7 +5,7 @@
   <div class="row">
     <div class="col-md-6" align="left">
       <h4>
-	Copyright &copy; 2016
+	Copyright &copy; 2016–{{ 'now' | date: "%Y" }}
 	{% if site.carpentry == "swc" %}
 	<a href="{{ site.swc_site }}">Software Carpentry Foundation</a>
 	{% elsif site.carpentry == "dc" %}


### PR DESCRIPTION
I used the same syntax as in _includes/lesson_footer.html so the copyright is 2016-<current year>.