### PR TITLE
Make 'surveys' section separate from 'schedule'

### DIFF
--- a/index.md
+++ b/index.md
@@ -184,17 +184,11 @@ and our administrator may contact you if we need any extra information.</h4>
 
 <hr/>
 
-{% comment %}
-  SCHEDULE
-
-  Show the workshop's schedule.  Edit the items and times in the table
-  to match your plans.  You may also want to change 'Day 1' and 'Day
-  2' to be actual dates or days of the week.
+{% comment %} 
+ SURVEYS - DO NOT EDIT SURVEY LINKS 
 {% endcomment %}
-<h2 id="schedule">Schedule</h2>
+<h2 id="surveys">Surveys</h2>
 
-{% comment %} DO NOT EDIT SURVEY LINKS {% endcomment %}
-<p><em>Surveys</em></p>
 {% if page.carpentry == "swc" %} 
 <p>Please be sure to complete these surveys before and after the workshop.</p>
 <p><a href="{{ site.swc_pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
@@ -207,6 +201,17 @@ and our administrator may contact you if we need any extra information.</h4>
 <p>Ask your instructor about pre- and post-workshop Survey details.</p>
 {% endif %}
 
+<hr/>
+
+
+{% comment %}
+  SCHEDULE
+
+  Show the workshop's schedule.  Edit the items and times in the table
+  to match your plans.  You may also want to change 'Day 1' and 'Day
+  2' to be actual dates or days of the week.
+{% endcomment %}
+<h2 id="schedule">Schedule</h2>
 
 {% if page.carpentry == "swc" %}
   {% include sc/schedule.html %}


### PR DESCRIPTION
Changed so that surveys are now in their own section. Having them in the Schedules section didn't make much sense