### PR TITLE
Remove analytics & redirect site search

### DIFF
--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -4,11 +4,3 @@
 <script src="{{ page.root }}/assets/js/jquery.min.js"></script>
 <script src="{{ page.root }}/assets/js/bootstrap.min.js"></script>
 <script src="{{ page.root }}/assets/js/lesson.js"></script>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-37305346-2', 'auto');
-  ga('send', 'pageview');
-</script>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -76,9 +76,9 @@
 	<li><a href="{{site.github.repository_url}}/edit/gh-pages/{{page.path}}">Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
 	{% endif %}
       </ul>
-      <form class="navbar-form navbar-right" role="search" id="search" onsubmit="google_search(); return false;">
+      <form class="navbar-form navbar-right" role="search" id="search" onsubmit="site_search(); return false;">
         <div class="form-group">
-          <input type="text" id="google-search" placeholder="Search..." aria-label="Google site search">
+          <input type="text" id="site-search" placeholder="Search..." aria-label="site search">
         </div>
       </form>
     </div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="last-modified" content="{{ site.time }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- meta "search-domain" used for google site search function google_search() -->
+    <!-- meta "search-domain" used for site search function site_search() -->
     <meta name="search-domain" value="{{ site.github.url }}">
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap-theme.css" />

--- a/assets/js/lesson.js
+++ b/assets/js/lesson.js
@@ -24,5 +24,5 @@ $(".solution").each(function() {
 function site_search() {
   var query = document.getElementById("site-search").value;
   var domain = $("meta[name=search-domain]").attr("value");
-  window.open("https://www.google.com/search?q=" + query + "+site:" + domain);
+  window.open("https://www.duckduckgo.com/lite/search?q=" + query + "+site:" + domain);
 }

--- a/assets/js/lesson.js
+++ b/assets/js/lesson.js
@@ -21,8 +21,8 @@ $(".solution").each(function() {
 
 // Handle searches.
 // Relies on document having 'meta' element with name 'search-domain'.
-function google_search() {
-  var query = document.getElementById("google-search").value;
+function site_search() {
+  var query = document.getElementById("site-search").value;
   var domain = $("meta[name=search-domain]").attr("value");
   window.open("https://www.google.com/search?q=" + query + "+site:" + domain);
 }


### PR DESCRIPTION
Hello :-)

while deriving up a workshop site from this template, I switched the search to DDG, as mentioned in https://github.com/swcarpentry/styles/issues/220 and removed the GA dependency. I'm sharing these commits here not so much as a request to merge them (spent only a few minutes looking for GA uses within the Carpentries, but found none), but in the hope that other workshop hosts find them useful.

Cheers!