### PR TITLE
Updated wording in intro for DC workshop

### DIFF
--- a/_includes/dc/intro.html
+++ b/_includes/dc/intro.html
@@ -1,11 +1,9 @@
 <p>
   <a href="{{site.dc_site}}">Data Carpentry</a>
-  aims to help researchers get their work done
-  in less time and with less pain
-  by teaching them basic research computing skills.
-  This hands-on workshop will cover basic concepts and tools,
-  including program design, version control, data management,
-  and task automation.
+  Data Carpentry develops and teaches workshops on the fundamental data skills needed to conduct
+  research. Its target audience is researchers who have little to no prior computational experience, 
+  and its lessons are domain specific, building on learners' existing knowledge to enable them to quickly 
+  apply skills learned to their own research.
   Participants will be encouraged to help one another
   and to apply what they have learned to their own research problems.
 </p>
@@ -13,6 +11,6 @@
   <em>
     For more information on what we teach and why,
     please see our paper
-    "<a href="http://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>".
+    "<a href="http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005510">Good Enough Practices for Scientific Computing</a>".
   </em>
 </p>

--- a/_includes/dc/intro.html
+++ b/_includes/dc/intro.html
@@ -1,6 +1,5 @@
 <p>
-  <a href="{{site.dc_site}}">Data Carpentry</a>
-  Data Carpentry develops and teaches workshops on the fundamental data skills needed to conduct
+  <a href="{{site.dc_site}}">Data Carpentry</a> develops and teaches workshops on the fundamental data skills needed to conduct
   research. Its target audience is researchers who have little to no prior computational experience, 
   and its lessons are domain specific, building on learners' existing knowledge to enable them to quickly 
   apply skills learned to their own research.


### PR DESCRIPTION
Previous wording reflected SWC intro. 
Also added the link to "Good enough practices in scientific computing|" rather than the best practices paper.