### PR TITLE
Link to OS-licensed RStudio directly

### DIFF
--- a/index.md
+++ b/index.md
@@ -619,7 +619,7 @@ and our administrator may contact you if we need any extra information.</h4>
     <a href="http://www.r-project.org">R</a> is a programming language
     that is especially powerful for data exploration, visualization, and
     statistical analysis. To interact with R, we use
-    <a href="http://www.rstudio.com/">RStudio</a>.
+    <a href="https://www.rstudio.com/">RStudio</a>.
   </p>
 
   <div class="row">
@@ -631,7 +631,7 @@ and our administrator may contact you if we need any extra information.</h4>
         <a href="http://cran.r-project.org/bin/windows/base/release.htm">this .exe file</a>
         from <a href="http://cran.r-project.org/index.html">CRAN</a>.
         Also, please install the
-        <a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
+        <a href="https://www.rstudio.com/ide/download/desktop/#download">RStudio IDE</a>.
         Note that if you have separate user and admin accounts, you should run the 
         installers as administrator (right-click on .exe file and select "Run as 
         administrator" instead of double-clicking). Otherwise problems may occur later, 
@@ -646,7 +646,7 @@ and our administrator may contact you if we need any extra information.</h4>
         <a href="http://cran.r-project.org/bin/macosx/R-latest.pkg">this .pkg file</a>
         from <a href="http://cran.r-project.org/index.html">CRAN</a>.
         Also, please install the
-        <a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
+        <a href="https://www.rstudio.com/ide/download/desktop/#download">RStudio IDE</a>.
       </p>
     </div>
     <div class="col-md-4">
@@ -657,7 +657,7 @@ and our administrator may contact you if we need any extra information.</h4>
         you can use your package manager (e.g. for Debian/Ubuntu
         run <code>sudo apt-get install r-base</code> and for Fedora run
         <code>sudo dnf install R</code>).  Also, please install the
-        <a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
+        <a href="https://www.rstudio.com/ide/download/desktop/#download">RStudio IDE</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
It's clear that we can only ask learners to obtain "RStudio Desktop
Open Source License". Thus, we can bypass RStudio's version choice table.