### PR TITLE
Fix for #513 - not using site.title for title in some pages as the title either becomes too long or wrong if variable is not set correctly

### DIFF
--- a/_includes/main_title.html
+++ b/_includes/main_title.html
@@ -1,4 +1,4 @@
 {% comment %}
   Main title for lesson pages.
 {% endcomment %}
-<h1 class="maintitle"><a href="{{ page.root }}{% link index.md %}">{% if page.title %}: {{ page.title }}{% endif %}</h1>
+<h1 class="maintitle">{{ page.title }}</h1>

--- a/_includes/main_title.html
+++ b/_includes/main_title.html
@@ -1,4 +1,4 @@
 {% comment %}
   Main title for lesson pages.
 {% endcomment %}
-<h1 class="maintitle"><a href="{{ page.root }}{% link index.md %}">{{ site.title }}</a>{% if page.title %}: {{ page.title }}{% endif %}</h1>
+<h1 class="maintitle"><a href="{{ page.root }}{% link index.md %}">{% if page.title %}: {{ page.title }}{% endif %}</h1>


### PR DESCRIPTION
For for #513. Removed the use of site.title variable from the title of some pages. Kept the variable in _config.yml if it used by something else.