### PR TITLE
removed Windows installer in text editor section of installation

### DIFF
--- a/index.md
+++ b/index.md
@@ -464,20 +464,7 @@ and our administrator may contact you if we need any extra information.</h4>
       <h4 id="editor-windows">Windows</h4>
       <a href="https://www.youtube.com/watch?v=339AEqk9c-8">Video Tutorial</a>
       <p>
-        nano is a basic editor and the default that instructors use in the workshop.
-        To install it,
-        download the <a href="{{site.swc_installer}}">
-          {% if page.carpentry == "swc" %}
-          Software Carpentry
-          {% elsif page.carpentry == "dc" %}
-          Data Carpentry
-          {% elsif page.carpentry == "lc" %}
-          Library Carpentry
-          {% endif %}
-          Windows installer
-	</a>
-        and double click on the file to run it.
-        <strong>This installer requires an active internet connection.</strong>
+        nano is a basic editor and the default that instructors use in the workshop. It is installed with Git for Windows as described in the Bash shell section.
       </p>
       <p>
         Others editors that you can use are

--- a/index.md
+++ b/index.md
@@ -462,7 +462,6 @@ and our administrator may contact you if we need any extra information.</h4>
   <div class="row">
     <div class="col-md-4">
       <h4 id="editor-windows">Windows</h4>
-      <a href="https://www.youtube.com/watch?v=339AEqk9c-8">Video Tutorial</a>
       <p>
         nano is a basic editor and the default that instructors use in the workshop. It is installed with Git for Windows as described in the Bash shell section.
       </p>


### PR DESCRIPTION
Related to https://github.com/carpentries/workshop-template/issues/512 removed reference to the SWC Windows installer in the text editor section.