### PR TITLE
Fix broken survey links

### DIFF
--- a/_includes/dc/schedule.html
+++ b/_includes/dc/schedule.html
@@ -4,7 +4,7 @@
     <table class="table table-striped">
       <tr>
 	<td>Before starting</td>
-	<td><a href="{{ site.dc_pre_survey }}{{ site.github.project_title }}" target="_blank">Pre-workshop survey</a></td>
+	<td><a href="{{ site.pre_survey }}{{ site.github.project_title }}" target="_blank">Pre-workshop survey</a></td>
       </tr>
       <tr><td>Morning</td> <td> <a href="http://www.datacarpentry.org/spreadsheet-ecology-lesson/">Data organization in spreadsheets</a></td></tr>
       <tr><td> </td><td><a href="http://www.datacarpentry.org/OpenRefine-ecology-lesson/">OpenRefine for data cleaning</a></td></tr>
@@ -19,7 +19,7 @@
       <tr> <td>Afternoon</td><td><a href="http://www.datacarpentry.org/sql-ecology-lesson/">Data management with SQL</a></td></tr>
       <tr>
 	<td>Evening</td>
-	<td><a href="{{ site.dc_post_survey }}{{ site.github.project_title }}" target="_blank">Post-workshop survey</a></td>
+	<td><a href="{{ site.post_survey }}{{ site.github.project_title }}" target="_blank">Post-workshop survey</a></td>
       </tr>
       <tr>
 	<td> </td>

--- a/_includes/sc/schedule.html
+++ b/_includes/sc/schedule.html
@@ -2,7 +2,7 @@
   <div class="col-md-6">
     <h3>Day 1</h3>
     <table class="table table-striped">
-      <tr> <td>Before</td> <td><a href="{{ site.swc_pre_survey }}{{ site.github.project_title }}">Pre-workshop survey</a> </td> </tr>
+      <tr> <td>Before</td> <td><a href="{{ site.pre_survey }}{{ site.github.project_title }}">Pre-workshop survey</a> </td> </tr>
       <tr> <td>09:00</td>  <td>Automating tasks with the Unix shell</td> </tr>
       <tr> <td>10:30</td>  <td>Coffee</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
@@ -21,7 +21,7 @@
       <tr> <td>13:00</td>  <td>Managing data with SQL</td> </tr>
       <tr> <td>14:30</td>  <td>Coffee</td> </tr>
       <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
-      <tr> <td>16:30</td>  <td><a href="{{ site.swc_post_survey }}{{ site.github.project_title }}" target="_blank">Post-workshop Survey</a></td> </tr>
+      <tr> <td>16:30</td>  <td><a href="{{ site.post_survey }}{{ site.github.project_title }}" target="_blank">Post-workshop Survey</a></td> </tr>
       <tr> <td>16:40</td>  <td>END</td> </tr>
     </table>
   </div>

--- a/index.md
+++ b/index.md
@@ -189,19 +189,10 @@ and our administrator may contact you if we need any extra information.</h4>
 {% endcomment %}
 <h2 id="surveys">Surveys</h2>
 <p>Please be sure to complete these surveys before and after the workshop.</p>
-{% if site.carpentry == "swc" %} 
-<p><a href="{{ site.swc_pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
-<p><a href="{{ site.swc_post_survey }}{{ site.github.project_title }}">Post-workshop Survey</a></p>
-{% elsif site.carpentry == "dc" %}
-<p><a href="{{ site.dc_pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
-<p><a href="{{ site.dc_post_survey }}{{ site.github.project_title }}">Post-workshop Survey</a></p>
-{% elsif site.carpentry == "lc" %}
-<p><a href="{{ site.lc_pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
-<p><a href="{{ site.lc_post_survey }}{{ site.github.project_title }}">Post-workshop Survey</a></p>
-{% endif %}
+<p><a href="{{ site.pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
+<p><a href="{{ site.post_survey }}{{ site.github.project_title }}">Post-workshop Survey</a></p>
 
 <hr/>
-
 
 {% comment %}
   SCHEDULE


### PR DESCRIPTION
Currently the survey links in the workshop template are broken.  This seems to be because the survey definitions changed from having individual dc and swc surveys to having a combined survey.  But whoever manages the survey should confirm that this is correct.