### PR TITLE
Fix #540

### DIFF
--- a/_includes/workshop_footer.html
+++ b/_includes/workshop_footer.html
@@ -19,7 +19,7 @@
     </div>
     <div class="col-md-6" align="right">
       <h4>
-	<a href="mailto:{{ site.email }}">Contact</a>
+	<a href="mailto:{{ site.email }}">Contact The Carpentries</a>
       </h4>
     </div>
   </div>


### PR DESCRIPTION
Change link text for "Contact" link at bottom of page (in `_includes/workshop_footer.html`) to "Contact The Carpentries".