### PR TITLE
Corrected SQLite Windows Installer Link

### DIFF
--- a/index.md
+++ b/index.md
@@ -667,7 +667,7 @@ and our administrator may contact you if we need any extra information.</h4>
     <div class="col-md-4">
       <h4 id="sql-windows">Windows</h4>
       <p>
-        The <a href="{{site.swc_installer}}">
+        The <a href="https://www.sqlite.org/download.html">
           {% if page.carpentry == "swc" %}
           Software Carpentry
           {% elsif page.carpentry == "dc" %}


### PR DESCRIPTION
The original SQLite Windows Installer Link will point to the workshop page, it will point to the SQLite download page after the changes.