### PR TITLE
Check for jupyter rather than IPython dependency.

### DIFF
--- a/setup/swc-installation-test-1.py
+++ b/setup/swc-installation-test-1.py
@@ -49,6 +49,7 @@ def check():
 if __name__ == '__main__':
     if check():
         print('Passed')
+        print('version of Python: ' + _sys.version)
     else:
         print('Failed')
         print('Install a current version of Python 3!')

--- a/setup/swc-installation-test-2.py
+++ b/setup/swc-installation-test-2.py
@@ -160,7 +160,7 @@ class DependencyError (Exception):
         ('*', '*', 'google-chrome'): 'https://www.google.com/intl/en/chrome/browser/',
         ('*', '*', 'hg'): 'http://mercurial.selenic.com/',
         ('*', '*', 'mercurial'): 'http://mercurial.selenic.com/',
-        ('*', '*', 'IPython'): 'http://ipython.org/install.html',
+        ('*', '*', 'jupyter'): 'http://jupyter.org/install.html',
         ('*', '*', 'ipython'): 'http://ipython.org/install.html',
         ('*', '*', 'jinja'): 'http://jinja.pocoo.org/docs/intro/#installation',
         ('*', '*', 'kate'): 'http://kate-editor.org/get-it/',

--- a/setup/swc-installation-test-2.py
+++ b/setup/swc-installation-test-2.py
@@ -109,7 +109,7 @@ CHECKS = [
 # Python
     'python',
     'ipython',         # Command line tool
-    'IPython',         # Python package
+    'jupyter',         # Former IPython features, notebook, etc.
     'argparse',        # Useful for utility scripts
     'numpy',
     'scipy',


### PR DESCRIPTION
Hello @k8hertweck and everyone!

I'm preparing for an [upcoming workshop](https://mkcor.github.io/2018-11-14-trento/) so I was running the installation scripts myself.

I will be teaching the [Plotting and Programming in Python](http://swcarpentry.github.io/python-novice-gapminder/) lesson, which uses Python 3 rather than Python 2.

I believe that, for everything Python we teach, we want to update `IPython` into `jupyter` in the template setup test script.

Thank you,
Marianne