### PR TITLE
Update syllabus for shell in dc folder

### DIFF
--- a/_includes/dc/syllabus.html
+++ b/_includes/dc/syllabus.html
@@ -2,12 +2,11 @@
   <div class="col-md-6">
     <h3 id="syllabus-shell">The Unix Shell</h3>
     <ul>
-      <li>Files and directories</li>
-      <li>History and tab completion</li>
-      <li>Pipes and redirection</li>
-      <li>Looping over files</li>
-      <li>Creating and running shell scripts</li>
-      <li>Finding things</li>
+      <li>Navigating Files and Directories</li>
+      <li>Working with Files and Directories</li>
+      <li>Redirection</li>
+      <li>Writing Scripts</li>
+      <li>Project Organization</li>
       <li><a href="{{site.swc_pages}}/shell-novice/reference">Reference...</a></li>
     </ul>
   </div>


### PR DESCRIPTION
I've noticed that the syllabus for the data folder for the shell training was using the software carpentry course instead of the data carpentry one. 
If I misunderstood the syllabus content, then please discard my pull request, as I am fairly new to your organisation.
Many thanks for considering it.

