### PR TITLE
Adjust PATH wording to Git 2.20.0 installer

### DIFF
--- a/index.md
+++ b/index.md
@@ -330,7 +330,7 @@ and our administrator may contact you if we need any extra information.</h4>
             </li>
             {% comment %} Adjusting your PATH environment {% endcomment %}
             <li>
-                Keep "Use Git from the Windows Command Prompt" selected and click on "Next".
+                Keep "Use Git from the command line and..." selected and click on "Next".
                 If you forgot to do this programs that you need for the workshop will not work properly.
                 If this happens rerun the installer and select the appropriate option.
             </li>


### PR DESCRIPTION
I'm not sure when this changed, but during preparation of a workshop, I was just notified that our current wording is off.

![grafik](https://user-images.githubusercontent.com/9948149/49925025-17b55f00-feb8-11e8-8c0b-3651833dc7a7.png)
