### PR TITLE
Let Xcode install Git on macOS (alternative to #485)

### DIFF
--- a/index.md
+++ b/index.md
@@ -423,19 +423,21 @@ and our administrator may contact you if we need any extra information.</h4>
     </div>
     <div class="col-md-4">
       <h4 id="git-macosx">macOS</h4>
-      <a href="https://www.youtube.com/watch?v=9LQhwETCdwY ">Video Tutorial</a>
       <p>
-        <strong>For OS X 10.9 and higher</strong>, install Git for Mac
-        by downloading and running the most recent "mavericks" installer from
-        <a href="http://sourceforge.net/projects/git-osx-installer/files/">this list</a>.
-        Because this installer is not signed by the developer, you may have to
-        right click (control click) on the .pkg file, click Open, and click
-        Open on the pop up window. 
-        After installing Git, there will not be anything in your <code>/Applications</code> folder,
-        as Git is a command line program.
+        Please open the Terminal app, type <code>git --version</code> and press 
+        <kbd>Enter</kbd>/<kbd>Return</kbd>. If it's not installed already, 
+        follow the instructions to <code>Install</code> the "command line 
+        developer tools". <strong>Don't click</strong> "Get Xcode", because that will 
+        take too long and is not necessary for our Git lesson.
+        After installing these tools, there won't be anything in your <code>/Applications</code>
+        folder, as they and Git are command line programs.
         <strong>For older versions of OS X (10.5-10.8)</strong> use the
         most recent available installer labelled "snow-leopard"
         <a href="http://sourceforge.net/projects/git-osx-installer/files/">available here</a>.
+        Because this installer is not signed by the developer, you may have to
+        right click (control click) on the .pkg file, click Open, and click
+        Open in the pop-up dialog. You can watch 
+        <a href="https://www.youtube.com/watch?v=9LQhwETCdwY ">a video tutorial about this case</a>.
       </p>
     </div>
     <div class="col-md-4">


### PR DESCRIPTION
As suggested in #485. Only one of either that PR or this one should be merged, not both ;-)

Because this Xcode-based install is signed, there are no security prompts we have to ask learners to bypass. Also, Apple will provide learners with Git updates automatically.

_Edit: Screenshot for completeness, posterity & illustration._

<img width="339" alt="xcode-cldt" src="https://user-images.githubusercontent.com/9948149/51086074-30789500-1742-11e9-8dee-0173c5c14915.png">

