### PR TITLE
Remove extra hyperlink HTML tags

### DIFF
--- a/_includes/dc/syllabus.html
+++ b/_includes/dc/syllabus.html
@@ -126,11 +126,11 @@
   <div class="col-md-6">
     <h3 id="syllabus-socialsci-r">Introduction to R</h3>
     <ul>
-      <li><a href="https://datacarpentry.org/r-socialsci/00-intro/index.html">Overview of R and Rstudio</a></a></li>
-      <li><a href="https://datacarpentry.org/r-socialsci/01-intro-to-r/index.html">Introduction to R</a></a></li>
-      <li><a href="https://datacarpentry.org/r-socialsci/02-starting-with-data/index.html">Starting with data</a></a></li>
-      <li><a href="https://datacarpentry.org/r-socialsci/03-dplyr-tidyr/index.html">Manipulating data frames with <code>dplyr</code></a></a></li>
-      <li><a href="https://datacarpentry.org/r-socialsci/04-ggplot2/index.html">Data visualisation with <code>ggplot2</code></a></a></li>
+      <li><a href="https://datacarpentry.org/r-socialsci/00-intro/index.html">Overview of R and Rstudio</a></li>
+      <li><a href="https://datacarpentry.org/r-socialsci/01-intro-to-r/index.html">Introduction to R</a></li>
+      <li><a href="https://datacarpentry.org/r-socialsci/02-starting-with-data/index.html">Starting with data</a></li>
+      <li><a href="https://datacarpentry.org/r-socialsci/03-dplyr-tidyr/index.html">Manipulating data frames with <code>dplyr</code></a></li>
+      <li><a href="https://datacarpentry.org/r-socialsci/04-ggplot2/index.html">Data visualisation with <code>ggplot2</code></a></li>
     </ul>
   </div>
 -->


### PR DESCRIPTION
There's an extra </a> tag for each of these links. Fixing so future folks who use this workshop template have a correctly formatted version.