### PR TITLE
Updating Travis to python3.6, and pyyaml checker and also updating the sql install instructions for !dc and dc workshops.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
   - "python bin/_travis.py"  
 script:
   - python bin/workshop_check.py .
+  - python -m unittest bin/_test/bs4test.py 
 branches:
   only:
     - gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,15 @@
 language: python
 python:
-  - "3.2"
-  - "3.3"
-  - "3.4"
+  - "3.6"
+# Remember that the code is running on a 14.04 machine.  
+#  - "3.4"
 # command to install dependencies
 install:
-  - pip install -r requirements.txt
+  - pip install -r requirements.txt  
+    # as per https://docs.travis-ci.com/user/installing-dependencies/  
 # command to run tests
 before_script:
-  - "awk -i inplace 'FNR == 4 {print \"carpentry: swc\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 5 {print \"venue: Foo\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 6 {print \"address: Room 123\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 7 {print \"country: us\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 8 {print \"language: en\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 9 {print \"latlng: 0,0\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 10 {print \"humandate: Jan 01-02, 2020\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 11 {print \"humantime: 9:00 am - 4:30 pm\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 12 {print \"startdate: 2020-01-01\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 13 {print \"enddate: 2020-01-01\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 14 {print \"instructor: [Foo]\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 15 {print \"helper: [Foo]\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 16 {print \"contact: [foo@bar.com]\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 17 {print \"collaborative_notes: http://foo.bar\"} {print}' index.md"
-  - "awk -i inplace 'FNR == 18 {print \"eventbrite: 1234567890AB\"} {print}' index.md"
+  - "python bin/_travis.py"  
 script:
   - python bin/workshop_check.py .
 branches:

--- a/bin/_test/bs4test.py
+++ b/bin/_test/bs4test.py
@@ -1,0 +1,31 @@
+import unittest
+from bs4 import BeautifulSoup
+import os
+from pathlib import Path
+from git_root import git_root
+
+class beautifulSoupTests(unittest.TestCase):
+	""" 
+	This test sets up a bs4 (https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-beautiful-soup) 
+	runner for tests of index.md that do not require a web browser.
+	"""
+
+	#https://github.com/jtilly/git_root
+	soup = BeautifulSoup("", 'html.parser')
+	def setUp(self):
+		with open(Path(git_root()) / 'index.md', "r") as index:
+			indexpage = index.read()
+		self.soup = BeautifulSoup(indexpage , 'html.parser')
+
+	def test_for_active_css_in_tabs(self):
+		"""
+		As per https://github.com/carpentries/workshop-template/pull/573/files
+		all tab divs need to have the active class in index.md
+		"""
+		for article in self.soup.find_all("article"):
+			self.assertIn('active', article['class'])
+			self.assertIn('tab-pane', article['class'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bin/_travis.py
+++ b/bin/_travis.py
@@ -1,0 +1,32 @@
+import yaml
+import datetime
+# We need to split the incoming file
+with open("index.md", 'r') as reader:
+	# There are multiple yaml documents in the index.md	
+
+	blankbit, yaml_to_load, text = reader.read().split("---")
+
+yaml_data = yaml.load(yaml_to_load, Loader=yaml.Loader) # To deal with depreciation warnings, we need Loader=Loader
+
+	
+yaml_data['carpentry']="swc" 
+yaml_data['venue']="Foo" 
+yaml_data['address']="Room 123" 
+yaml_data['country']="us" 
+yaml_data['language']="en" 
+yaml_data['latlng']="0,0" 
+yaml_data['humandate']="Jan 01-02, 2020" 
+yaml_data['humantime']="9:00 am - 4:30 pm" 
+yaml_data['startdate']= datetime.datetime.today()
+yaml_data['enddate']= datetime.datetime.today()
+yaml_data['instructor']=["Foo"]
+yaml_data['helper']=["Foo"] 
+yaml_data['email']=["foo@bar.com"]
+yaml_data['collaborative_notes'] =  "http://foo.bar"
+yaml_data['eventbrite']="1234567890AB" 
+
+with open("index.md", "w") as writer:
+	writer.write("---\n") #blankbit is technically a yaml document
+	yaml.dump(yaml_data, writer)
+	writer.write("---\n")
+	writer.write(text)

--- a/getsql.sh
+++ b/getsql.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+if command -v apt-get >/dev/null 2>&1 ; then
+	sudo apt-get install sqlite3
+elif  command -v unzip >/dev/null 2>^1 ; then
+	mkdir -p ~/bin
+	curl https://www.sqlite.org/2019/sqlite-tools-win32-x86-3270200.zip > sql.zip
+	unzip sql.zip
+	mv sqlite-tools-win32-x86-3270200/* ~/bin/
+	rm -rf sqlite-tools-win32-x86-3270200
+	echo 'export PATH="$PATH:$HOME/bin"' >> .bash_profile
+	source .bash_profile
+	sqlite3 --version
+	# 3.27.2 2019-02-25 16:06:06 bd49a8271d650fa89e446b42e513b595a717b9212c91dd384aab871fc1d0f6d7
+else
+	echo "I cannot find apt or unzip. Please ask an instructor for help."
+fi

--- a/index.md
+++ b/index.md
@@ -389,7 +389,7 @@ please preview your site before committing, and make sure to run
         </ol>
         <p>This will provide you with both Git and Bash in the Git Bash program.</p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="shell-macos">
+      <article role="tabpanel" class="tab-pane active" id="shell-macos">
         <p>
           The default shell in all versions of macOS is Bash, so no
           need to install anything.  You access Bash from the Terminal
@@ -401,7 +401,7 @@ please preview your site before committing, and make sure to run
           Terminal in your dock for this workshop.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="shell-linux">
+      <article role="tabpanel" class="tab-pane active" id="shell-linux">
         <p>
           The default shell is usually Bash, but if your
           machine is set up differently you can run it by opening a
@@ -448,7 +448,7 @@ please preview your site before committing, and make sure to run
           install (described above).
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="git-macos">
+      <article role="tabpanel" class="tab-pane active" id="git-macos">
         <a href="https://www.youtube.com/watch?v=9LQhwETCdwY ">Video Tutorial</a>
         <p>
           <strong>For OS X 10.9 and higher</strong>, install Git for Mac
@@ -464,7 +464,7 @@ please preview your site before committing, and make sure to run
           <a href="http://sourceforge.net/projects/git-osx-installer/files/">available here</a>.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="git-linux">
+      <article role="tabpanel" class="tab-pane active" id="git-linux">
         <p>
           If Git is not already available on your machine you can try to
           install it via your distro's package manager. For Debian/Ubuntu run
@@ -512,7 +512,7 @@ please preview your site before committing, and make sure to run
           Please ask your instructor to help you do this.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="editor-macos">
+      <article role="tabpanel" class="tab-pane active" id="editor-macos">
         <p>
           nano is a basic editor and the default that instructors use in the workshop.
           See the Git installation <a href="https://www.youtube.com/watch?v=9LQhwETCdwY ">video tutorial</a>
@@ -525,7 +525,7 @@ please preview your site before committing, and make sure to run
           <a href="https://www.sublimetext.com/">Sublime Text</a>.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="editor-macos">
+      <article role="tabpanel" class="tab-pane active" id="editor-macos">
         <p>
           nano is a basic editor and the default that instructors use in the workshop.
           It should be pre-installed.
@@ -588,7 +588,7 @@ please preview your site before committing, and make sure to run
           <li>Install Python 3 using all of the defaults for installation <em>except</em> make sure to check <strong>Add Anaconda to my PATH environment variable</strong>.</li>
         </ol>
       </article>
-      <article role="tabpanel" class="tab-pane" id="python-macos">
+      <article role="tabpanel" class="tab-pane active" id="python-macos">
         <a href="https://www.youtube.com/watch?v=TcSAln46u9U">Video Tutorial</a>
         <ol>
           <li>Open <a href="https://www.anaconda.com/download/#macos">https://www.anaconda.com/download/#macos</a> with your web browser.</li>
@@ -596,7 +596,7 @@ please preview your site before committing, and make sure to run
           <li>Install Python 3 using all of the defaults for installation.</li>
         </ol>
       </article>
-      <article role="tabpanel" class="tab-pane" id="python-linux">
+      <article role="tabpanel" class="tab-pane active" id="python-linux">
         <ol>
           <li>Open <a href="https://www.anaconda.com/download/#linux">https://www.anaconda.com/download/#linux</a> with your web browser.</li>
           <li>Download the Python 3 installer for Linux.<br>
@@ -671,7 +671,7 @@ please preview your site before committing, and make sure to run
           for example when installing R packages.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="rstats-macos">
+      <article role="tabpanel" class="tab-pane active" id="rstats-macos">
         <a href="https://www.youtube.com/watch?v=5-ly3kyxwEg">Video Tutorial</a>
         <p>
           Install R by downloading and running
@@ -681,7 +681,7 @@ please preview your site before committing, and make sure to run
           <a href="https://www.rstudio.com/products/rstudio/download/#download">RStudio IDE</a>.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="rstats-linux">
+      <article role="tabpanel" class="tab-pane active" id="rstats-linux">
         <p>
           You can download the binary files for your distribution
           from <a href="https://cran.r-project.org/index.html">CRAN</a>. Or
@@ -720,12 +720,12 @@ please preview your site before committing, and make sure to run
           Visit <a href="https://sqlitebrowser.org/dl/">SqliteBrowser</a> and download and install it. Version 3.11.0 or greater.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="sql-macos">
+      <article role="tabpanel" class="tab-pane active" id="sql-macos">
         <p>
           Visit <a href="https://sqlitebrowser.org/dl/">SqliteBrowser</a> and download and install it. Version 3.11.0 or greater.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="sql-linux">
+      <article role="tabpanel" class="tab-pane active" id="sql-linux">
         <p>
           Visit <a href="https://sqlitebrowser.org/dl/">SqliteBrowser</a> and download and install it. Version 3.11.0 or greater.
         </p>
@@ -747,17 +747,17 @@ please preview your site before committing, and make sure to run
 
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="sql-macos">
+      <article role="tabpanel" class="tab-pane active" id="sql-macos">
         <p>
           SQLite comes pre-installed on macOS.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="sql-linux">
+      <article role="tabpanel" class="tab-pane active" id="sql-linux">
         <p>
           SQLite comes pre-installed on Linux.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane" id="sql-web">
+      <article role="tabpanel" class="tab-pane active" id="sql-web">
         <p>
           <ul>
             <li>In case of problems: register for an account at <a href="http://pythonanywhere.com/">Python Anywhere</a></li>

--- a/index.md
+++ b/index.md
@@ -346,7 +346,7 @@ please preview your site before committing, and make sure to run
               </li>
               <li>
                 <strong>
-                  Select “Use the nano editor by default” and click on “Next”.
+                  Select "Use the nano editor by default" and click on "Next".
                 </strong>
               </li>
               {% comment %} Adjusting your PATH environment {% endcomment %}
@@ -448,7 +448,7 @@ please preview your site before committing, and make sure to run
           install (described above).
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="git-macos">
+      <article role="tabpanel" class="tab-pane" id="git-macos">
         <a href="https://www.youtube.com/watch?v=9LQhwETCdwY ">Video Tutorial</a>
         <p>
           <strong>For OS X 10.9 and higher</strong>, install Git for Mac
@@ -464,7 +464,7 @@ please preview your site before committing, and make sure to run
           <a href="http://sourceforge.net/projects/git-osx-installer/files/">available here</a>.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="git-linux">
+      <article role="tabpanel" class="tab-pane" id="git-linux">
         <p>
           If Git is not already available on your machine you can try to
           install it via your distro's package manager. For Debian/Ubuntu run
@@ -512,7 +512,7 @@ please preview your site before committing, and make sure to run
           Please ask your instructor to help you do this.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="editor-macos">
+      <article role="tabpanel" class="tab-pane" id="editor-macos">
         <p>
           nano is a basic editor and the default that instructors use in the workshop.
           See the Git installation <a href="https://www.youtube.com/watch?v=9LQhwETCdwY ">video tutorial</a>
@@ -525,7 +525,7 @@ please preview your site before committing, and make sure to run
           <a href="https://www.sublimetext.com/">Sublime Text</a>.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="editor-macos">
+      <article role="tabpanel" class="tab-pane" id="editor-macos">
         <p>
           nano is a basic editor and the default that instructors use in the workshop.
           It should be pre-installed.
@@ -588,7 +588,7 @@ please preview your site before committing, and make sure to run
           <li>Install Python 3 using all of the defaults for installation <em>except</em> make sure to check <strong>Add Anaconda to my PATH environment variable</strong>.</li>
         </ol>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="python-macos">
+      <article role="tabpanel" class="tab-pane" id="python-macos">
         <a href="https://www.youtube.com/watch?v=TcSAln46u9U">Video Tutorial</a>
         <ol>
           <li>Open <a href="https://www.anaconda.com/download/#macos">https://www.anaconda.com/download/#macos</a> with your web browser.</li>
@@ -596,7 +596,7 @@ please preview your site before committing, and make sure to run
           <li>Install Python 3 using all of the defaults for installation.</li>
         </ol>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="python-linux">
+      <article role="tabpanel" class="tab-pane" id="python-linux">
         <ol>
           <li>Open <a href="https://www.anaconda.com/download/#linux">https://www.anaconda.com/download/#linux</a> with your web browser.</li>
           <li>Download the Python 3 installer for Linux.<br>
@@ -671,7 +671,7 @@ please preview your site before committing, and make sure to run
           for example when installing R packages.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="rstats-macos">
+      <article role="tabpanel" class="tab-pane" id="rstats-macos">
         <a href="https://www.youtube.com/watch?v=5-ly3kyxwEg">Video Tutorial</a>
         <p>
           Install R by downloading and running
@@ -681,7 +681,7 @@ please preview your site before committing, and make sure to run
           <a href="https://www.rstudio.com/products/rstudio/download/#download">RStudio IDE</a>.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="rstats-linux">
+      <article role="tabpanel" class="tab-pane" id="rstats-linux">
         <p>
           You can download the binary files for your distribution
           from <a href="https://cran.r-project.org/index.html">CRAN</a>. Or
@@ -709,36 +709,66 @@ please preview your site before committing, and make sure to run
       <li role="presentation" class="active"><a data-os="windows" href="#sql-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
       <li role="presentation"><a data-os="macos" href="#sql-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
       <li role="presentation"><a data-os="linux" href="#sql-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>
+      {% if page.carpentry != 'dc' %}
+      <li role="presentation"><a data-os="Web" href="#sql-web" aria-controls="Linux" role="tab" data-toggle="tab">Web</a></li>
+      {% endif %}
     </ul>
-
+    {% if page.carpentry == 'dc' %}
     <div class="tab-content">
       <article role="tabpanel" class="tab-pane active" id="sql-windows">
         <p>
-          The <a href="https://www.sqlite.org/download.html">
-            {% if page.carpentry == "swc" %}
-            Software Carpentry
-            {% elsif page.carpentry == "dc" %}
-            Data Carpentry
-            {% elsif page.carpentry == "lc" %}
-            Library Carpentry
-            {% endif %}
-            Windows Installer
-	  </a>
-          installs SQLite for Windows.
-          If you used the installer to configure nano, you don't need to run it again.
+          Visit <a href="https://sqlitebrowser.org/dl/">SqliteBrowser</a> and download and install it. Version 3.11.0 or greater.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="sql-macos">
+      <article role="tabpanel" class="tab-pane" id="sql-macos">
+        <p>
+          Visit <a href="https://sqlitebrowser.org/dl/">SqliteBrowser</a> and download and install it. Version 3.11.0 or greater.
+        </p>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="sql-linux">
+        <p>
+          Visit <a href="https://sqlitebrowser.org/dl/">SqliteBrowser</a> and download and install it. Version 3.11.0 or greater.
+        </p>
+      </article>
+      
+    </div>
+    {%else%}
+    <div class="tab-content">
+      <article role="tabpanel" class="tab-pane active" id="sql-windows">
+        <p>
+          <ul>
+            <li>Run git-bash from the start menu</li>
+            <li>Copy the following <code>curl {{site.url}}{{site.baseurl}}/getsql.sh | bash</code></li>
+            <li>Paste it into the window that git bash opened. If you're unsure, ask an instructor for help</li>
+            <li>You should see something like <code>3.27.2 2019-02-25 16:06:06 ...</code></li>
+          </ul>
+            
+          <p>If you want to do this manually, download <a href="https://www.sqlite.org/2019/sqlite-tools-win32-x86-3270200.zip">sqlite3</a>, make a bin directory in the user's home directory, unzip sqlite3, move it into the bin directory, and then add the bin directory to the path.</p>
+
+        </p>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="sql-macos">
         <p>
           SQLite comes pre-installed on macOS.
         </p>
       </article>
-      <article role="tabpanel" class="tab-pane active" id="sql-linux">
+      <article role="tabpanel" class="tab-pane" id="sql-linux">
         <p>
           SQLite comes pre-installed on Linux.
         </p>
       </article>
+      <article role="tabpanel" class="tab-pane" id="sql-web">
+        <p>
+          <ul>
+            <li>In case of problems: register for an account at <a href="http://pythonanywhere.com/">Python Anywhere</a></li>
+            <li>Download <a href="http://swcarpentry.github.io/sql-novice-survey/files/survey.db">survey.db</a></li>
+            <li>Click on files and upload survey.db</li>
+            <li>Click on dashboard and Choose new console <code>$ bash</code></li>
+            </ul>
+        </p>
+      </article>
     </div>
+      {%endif%}
   </div>
 
   <p><strong>If you installed Anaconda, it also has a copy of SQLite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 PyYAML
+beautifulsoup4
+git_root


### PR DESCRIPTION
Made travis use a single instance of python 3.6 instead of 3 instance of 3.2 through 3.4 (since we're not testing the python scripts themselves), so that modern versions of ubuntu can run the files without problem. Gawk doesn't work in 14.04 with the inplace extension, so wrote a python script to do the same thing. Also, made invocations to yaml.Loader so that we're not bitten by depreciation alerts becoming fact in the future. 

And then made a second commit (sorry I can't figure out how to make it its own pull request, regarding issue #584 ) Which updates the sql install instructions to not be a misleading link, adds a bash curl oneliner to deploy swc sqlite in git-bash, and if the workshop is a dc workshop, to point them to the sqlite browser.