### PR TITLE
Update GitHub organization in citation link

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,5 +1,5 @@
 Please cite as:
 
 Greg Wilson (ed): "Software Carpentry: Workshop Template."  Version
-2016.06, June 2016, https://github.com/swcarpentry/workshop-template,
+2016.06, June 2016, https://github.com/carpentries/workshop-template,
 10.5281/zenodo.58156.


### PR DESCRIPTION
It's being redirected, so the link doesn't really need to be updated while there is no new release of this template.