### PR TITLE
Editing the getsql install script to account for winpty

### DIFF
--- a/getsql.sh
+++ b/getsql.sh
@@ -7,9 +7,11 @@ elif  command -v unzip >/dev/null 2>^1 ; then
 	mkdir -p ~/bin
 	curl https://www.sqlite.org/2019/sqlite-tools-win32-x86-3270200.zip > sql.zip
 	unzip sql.zip
-	mv sqlite-tools-win32-x86-3270200/* ~/bin/
+	mv sqlite-tools-win32-x86-3270200/* ~/bin/	
 	rm -rf sqlite-tools-win32-x86-3270200
 	echo 'export PATH="$PATH:$HOME/bin"' >> .bash_profile
+	echo 'alias sqlite3="winpty sqlite3"' >> .bash_profile
+	echo 'alias nano="winpty nano"' >> .bash_profile
 	source .bash_profile
 	sqlite3 --version
 	# 3.27.2 2019-02-25 16:06:06 bd49a8271d650fa89e446b42e513b595a717b9212c91dd384aab871fc1d0f6d7

--- a/getsql.sh
+++ b/getsql.sh
@@ -10,8 +10,7 @@ elif  command -v unzip >/dev/null 2>^1 ; then
 	mv sqlite-tools-win32-x86-3270200/* ~/bin/	
 	rm -rf sqlite-tools-win32-x86-3270200
 	echo 'export PATH="$PATH:$HOME/bin"' >> .bash_profile
-	echo 'alias sqlite3="winpty sqlite3"' >> .bash_profile
-	echo 'alias nano="winpty nano"' >> .bash_profile
+	echo 'alias sqlite3="winpty sqlite3"' >> .bash_profile	
 	source .bash_profile
 	sqlite3 --version
 	# 3.27.2 2019-02-25 16:06:06 bd49a8271d650fa89e446b42e513b595a717b9212c91dd384aab871fc1d0f6d7


### PR DESCRIPTION
Some students in my recent workshop did not install git bash correctly, and we had some issues with them running sqlite3. Updated my installer to alias winpty as part of the sqlite3 install, and tested on fresh copy of windows server.