### PR TITLE
Include schedule for geospatial workshop

### DIFF
--- a/_includes/dc/schedule.html
+++ b/_includes/dc/schedule.html
@@ -104,3 +104,39 @@ Social Science workshop
   </div>
 </div>
 -->
+
+<!--
+Geospatial workshop
+-->
+<!--
+<div class="row">
+  <div class="col-md-6">
+    <h3>Day 1</h3>
+    <table class="table table-striped">
+      <tr>
+	<td>Before starting</td>
+	<td><a href="{{ site.dc_pre_survey }}{{ site.github.project_title }}" target="_blank">Pre-workshop survey</a></td>
+      </tr>
+      <tr><td>Morning</td> <td> <a href="https://datacarpentry.org/organization-geospatial/">Introduction to Geospatial Concepts</a></td></tr>
+      <tr><td> </td><td><a href="https://datacarpentry.org/r-intro-geospatial/">Introduction to R for Geospatial Data</a></td></tr>
+      <tr><td>Afternoon</td><td><a href="https://datacarpentry.org/r-raster-vector-geospatial/">Introduction to Geospatial Raster Data</a></td></tr>
+      <tr> <td>Evening</td> <td>END</td> </tr>
+    </table>
+  </div>
+  <div class="col-md-6">
+    <h3>Day 2</h3>
+    <table class="table table-striped">
+      <tr> <td>Morning</td> <td><a href="https://datacarpentry.org/r-raster-vector-geospatial/">Continuation of Geospatial Raster Data</a></td></tr>
+      <tr> <td>Afternoon</td><td><a href="https://datacarpentry.org/r-raster-vector-geospatial/06-vector-open-shapefile-in-r/index.html">Introduction to Geospatial Vector Data</a></td></tr>
+      <tr>
+	<td>Evening</td>
+	<td><a href="{{ site.dc_post_survey }}{{ site.github.project_title }}" target="_blank">Post-workshop survey</a></td>
+      </tr>
+      <tr>
+	<td> </td>
+	<td> END </td>
+      </tr>
+    </table>
+  </div>
+</div>
+-->


### PR DESCRIPTION
Included all sections of the geospatial workshop in this sample schedule, but I think the main curriculum (Introduction to Geospatial Raster and Vector Data) is enough by itself to cover two days

Addresses datacarpentry/geospatial-workshop#33.