### PR TITLE
Change swc to sc for _includes docs

### DIFF
--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -109,7 +109,7 @@ The header may optionally define the following:
 
 You should edit the sections titled `Schedule` and `Syllabus`
 so that they show what you're actually planning to teach and when.  These 
-files are located in the appropriate workshop folder (`dc`, `lc` or `swc`) 
+files are located in the appropriate workshop folder (`dc`, `lc` or `sc`) 
 inside the `_includes` folder.  
 
 ## Home Page: Setup


### PR DESCRIPTION
On the customizations page, the documents incorrectly point you to the _includes/swc folder for customizing the Schedule and Syllabus.  The name of the folder is really _includes/sc.
