### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ enddate: FIXME        # machine-readable end date for the workshop in YYYY-MM-DD
 instructor: ["FIXME"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["FIXME"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["fixme@example.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
-collaborative_notes:             # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document
+etherpad:             # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document, like "https://pad.carpentries.org/2019-08-27-example"
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---
 


### PR DESCRIPTION
The instructions refer to "etherpad" not "collaborative_notes" for a URL to Etherpad etc. The latter does not work but the former does.

It would also be good to add an example quoted URL, as per the commit.