### PR TITLE
make "carpentries" a non-mandatory header key

### DIFF
--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -264,7 +264,7 @@ def check_pass(value):
 HANDLERS = {
     'layout':     (True, check_layout, 'layout isn\'t "workshop"'),
 
-    'carpentry':  (True, check_carpentry, 'carpentry isn\'t in ' +
+    'carpentry':  (False, check_carpentry, 'carpentry isn\'t in ' +
                    ', '.join(CARPENTRIES)),
 
     'country':    (True, check_country,

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -18,7 +18,6 @@ EVENTBRITE_PATTERN = r'\d{9,10}'
 URL_PATTERN = r'https?://.+'
 
 # Defaults.
-CARPENTRIES = ("dc", "swc", "lc", "cp")
 DEFAULT_CONTACT_EMAIL = 'admin@software-carpentry.org'
 
 USAGE = 'Usage: "workshop_check.py path/to/root/directory"'
@@ -87,13 +86,6 @@ def check_layout(layout):
     '''"layout" in YAML header must be "workshop".'''
 
     return layout == 'workshop'
-
-
-@look_for_fixme
-def check_carpentry(layout):
-    '''"carpentry" in YAML header must be "dc", "swc", "lc", or "cp".'''
-
-    return layout in CARPENTRIES
 
 
 @look_for_fixme
@@ -263,9 +255,6 @@ def check_pass(value):
 
 HANDLERS = {
     'layout':     (True, check_layout, 'layout isn\'t "workshop"'),
-
-    'carpentry':  (False, check_carpentry, 'carpentry isn\'t in ' +
-                   ', '.join(CARPENTRIES)),
 
     'country':    (True, check_country,
                    'country invalid: must use lowercase two-letter ISO code ' +


### PR DESCRIPTION
closes #637 

I'm not 100% sure that just making `carpentry` into an optional key is the right fix here; is there ever a case where we *do* still want that key?  If not, then deleting the `check_carpentry` function and the `carpentry` entry in `HANDLERS` might make more sense.