### PR TITLE
Fix humantime regex error message

### DIFF
--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -280,7 +280,9 @@ HANDLERS = {
                    '"Jan" and four-letter years like "2025"'),
 
     'humantime':  (True, check_humantime,
-                   'humantime doesn\'t include numbers'),
+                   'humantime is misformatted. Acceptable formats are '
+                   '"9:00 am - 5:00 pm", "09:00am - 05:00pm", "09:00-17:00" '
+                   '(spaces are ignored).'),
 
     'startdate':  (True, check_date,
                    'startdate invalid. Must be of format year-month-day, ' +


### PR DESCRIPTION
This PR:

- allows uppercase letters in `humantime` (am/pm)
- makes minutes optional (allows "9am-5:30pm" instead of forcing "9:00am-5:30pm")
- improves the error message when humantime fails to match the regex
