### PR TITLE
make collaborative note a section

### DIFF
--- a/index.md
+++ b/index.md
@@ -208,8 +208,28 @@ Everyone who participates in Carpentries activities is required to conform to th
 <p class="text-center">
 <button type="button" class="btn btn-info">Report a Code of Conduct Incident</button>
 </p>
-
 <hr/>
+
+
+{% comment %}
+Collaborative Notes
+
+If you want to use an Etherpad, go to
+
+http://pad.carpentries.org/YYYY-MM-DD-site
+
+where 'YYYY-MM-DD-site' is the identifier for your workshop,
+e.g., '2015-06-10-esu'.
+{% endcomment %}
+{% if page.collaborative_notes %}
+<h2 id="collaborative_notes">Collaborative Notes</h2>
+
+<p>
+We will use this <a href="{{page.collaborative_notes}}">collaborative document</a> for chatting, taking notes, and sharing URLs and bits of code.
+</p>
+<hr/>
+{% endif %}
+
 
 {% comment %} 
 SURVEYS - DO NOT EDIT SURVEY LINKS 
@@ -237,22 +257,6 @@ to match your plans.  You may also want to change 'Day 1' and 'Day
 {% include dc/schedule.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/schedule.html %}
-{% endif %}
-
-{% comment %}
-Collaborative Notes
-
-If you want to use an Etherpad, go to
-
-http://pad.carpentries.org/YYYY-MM-DD-site
-
-where 'YYYY-MM-DD-site' is the identifier for your workshop,
-e.g., '2015-06-10-esu'.
-{% endcomment %}
-{% if page.collaborative_notes %}
-<p id="collaborative_notes">
-  We will use this <a href="{{page.collaborative_notes}}">collaborative document</a> for chatting, taking notes, and sharing URLs and bits of code.
-</p>
 {% endif %}
 
 <hr/>


### PR DESCRIPTION
address #635 

If a link for a collaborative notes document is included in `index.md` instead of having the link to access the etherpad go unnoticed under "General Information", make it its own section.