### PR TITLE
update online link to use page.address

### DIFF
--- a/_includes/workshop_ad.html
+++ b/_includes/workshop_ad.html
@@ -21,7 +21,7 @@
       <div class="row">
         <div class="col-md-6">
           {% if online == "true_public" %}
-          <p>Online (<a href="{{site.address}}">link</a>)</p>
+          <p>Online (<a href="{{page.address}}">link</a>)</p>
           {% elsif online == "true_private" %}
           <p>Online</p>
           {% endif %}


### PR DESCRIPTION
The link to online workshops was pointing back to the initial site address, so I've changed it to link to the link to the online meeting.
