### PR TITLE
Adding adblocker warning

### DIFF
--- a/index.md
+++ b/index.md
@@ -74,6 +74,8 @@ are not using Eventbrite, or leave it in, since it will not be
 displayed if the 'eventbrite' field in the header is not set.
 {% endcomment %}
 {% if page.eventbrite %}
+<strong>Some adblockers block the registration window. If you do not see the 
+  registration box below, please check your adblocker settings.</strong>
 <iframe
   src="https://www.eventbrite.com/tickets-external?eid={{page.eventbrite}}&ref=etckt"
   frameborder="0"


### PR DESCRIPTION
I heard back from someone who recently registered that they had trouble initially finding the registration because their adblocker prevented them from seeing the eventbrite box.  
Not sure this is the best wording so feel free to edit!