### PR TITLE
add link to role description

### DIFF
--- a/index.md
+++ b/index.md
@@ -212,7 +212,7 @@ CONTACT EMAIL ADDRESS
 Display the contact email address set in the configuration file.
 {% endcomment %}
 <p id="contact">
-  <strong>Contact</strong>:
+  <strong>Contact:</strong>
   Please email
   {% if page.email %}
   {% for email in page.email %}
@@ -229,6 +229,12 @@ Display the contact email address set in the configuration file.
   to-be-announced
   {% endif %}
   for more information.
+</p>
+
+<p id="roles">
+  <strong>Roles:</strong>
+  To learn more about the roles at the workshop (who will be doing what),
+  refer to <a href="https://carpentries.org/workshop_faq/#what-are-the-roles-of-everyone-participating-in-a-workshop">our Workshop FAQ</a>.
 </p>
 
 <hr/>


### PR DESCRIPTION
add link to the description of the roles for people involved in a workshop.