### PR TITLE
typo in online instruction location

### DIFF
--- a/index.md
+++ b/index.md
@@ -151,7 +151,7 @@ address.
 {% elsif online == "true_private" %}
 <p id="where">
   <strong>Where:</strong> This training will take place online.
-  The instructors will provide you with the infromation you will need to connect to this meeting.
+  The instructors will provide you with the information you will need to connect to this meeting.
 </p>
 {% endif %}
 


### PR DESCRIPTION
Fixes a small typo in the tenmplated text for online workshop location

See #671
