### PR TITLE
index.md: remove redundant check

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ need any extra information.
 Check DC curriculum
 {% endcomment %}
 
-{% if site.carpentry == "dc" or site.carpentry == "dc" %}
+{% if site.carpentry == "dc" %}
 {% unless site.curriculum == "dc-ecology" or site.curriculum == "dc-genomics" or site.curriculum == "dc-socsci" or site.curriculum == "dc-geospatial" %}
 <div class="alert alert-warning">
 It looks like you are setting up a website for a Data Carpentry curriculum but you haven't specified the curriculum type in the <code>_config.yml</code> file (current value in <code>_config.yml</code>: "<strong>{{ site.curriculum }}</strong>", possible values: <code>dc-ecology</code>, <code>dc-genomics</code>, <code>dc-socsci</code>, or <code>dc-geospatial</code>). After editing this file, you need to run <code>make serve</code> again to see the changes reflected.


### PR DESCRIPTION
I think single `site.carpentry == "dc"` is sufficient