### PR TITLE
Don't justify OS tabs

### DIFF
--- a/_includes/install_instructions/editor.html
+++ b/_includes/install_instructions/editor.html
@@ -13,7 +13,7 @@
   </p>
 
   <div>
-    <ul class="nav nav-tabs nav-justified" role="tablist">
+    <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a data-os="windows" href="#editor-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
       <li role="presentation"><a data-os="macos" href="#editor-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
       <li role="presentation"><a data-os="linux" href="#editor-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>

--- a/_includes/install_instructions/git.html
+++ b/_includes/install_instructions/git.html
@@ -24,7 +24,7 @@ the text below accordingly.
   </p>
 
   <div>
-    <ul class="nav nav-tabs nav-justified" role="tablist">
+    <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a data-os="windows" href="#git-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
       <li role="presentation"><a data-os="macos" href="#git-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
       <li role="presentation"><a data-os="linux" href="#git-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>

--- a/_includes/install_instructions/openrefine.html
+++ b/_includes/install_instructions/openrefine.html
@@ -7,7 +7,7 @@
   </p>
 
   <div>
-    <ul class="nav nav-tabs nav-justified" role="tablist">
+    <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a data-os="windows" href="#openrefine-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
       <li role="presentation"><a data-os="macos" href="#openrefine-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
       <li role="presentation"><a data-os="linux" href="#openrefine-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -39,7 +39,7 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
   </p>
 
   <div>
-    <ul class="nav nav-tabs nav-justified" role="tablist">
+    <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a data-os="windows" href="#python-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
       <li role="presentation"><a data-os="macos" href="#python-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
       <li role="presentation"><a data-os="linux" href="#python-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>

--- a/_includes/install_instructions/r.html
+++ b/_includes/install_instructions/r.html
@@ -9,7 +9,7 @@
   </p>
 
   <div>
-    <ul class="nav nav-tabs nav-justified" role="tablist">
+    <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a data-os="windows" href="#rstats-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
       <li role="presentation"><a data-os="macos" href="#rstats-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
       <li role="presentation"><a data-os="linux" href="#rstats-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>

--- a/_includes/install_instructions/shell.html
+++ b/_includes/install_instructions/shell.html
@@ -6,7 +6,7 @@
   </p>
 
   <div>
-    <ul class="nav nav-tabs nav-justified" role="tablist">
+    <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a data-os="windows" href="#shell-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
       <li role="presentation"><a data-os="macos" href="#shell-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
       <li role="presentation"><a data-os="linux" href="#shell-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>

--- a/_includes/install_instructions/sql.html
+++ b/_includes/install_instructions/sql.html
@@ -8,7 +8,7 @@
   </p>
 
   <div>
-    <ul class="nav nav-tabs nav-justified" role="tablist">
+    <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a data-os="windows" href="#sql-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
       <li role="presentation"><a data-os="macos" href="#sql-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
       <li role="presentation"><a data-os="linux" href="#sql-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>


### PR DESCRIPTION
I'd like to suggest not using justification for tabs. This way tabs for different OS-es will appear closer to each other.
This is what proposed change will make OS strip look like (except for the background-color -- I'll submit it as a PR to carpentries/styles).

![image](https://user-images.githubusercontent.com/13123663/85886404-a8f2da80-b7ab-11ea-9ede-1bd44c111cf9.png)
