### PR TITLE
[fix #668] include videoconferencing installation instructions

### DIFF
--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -145,6 +145,11 @@ following modifications:
   host institution. If it does not, use `0` for both the latitude and the
   longitude.
 
+By default, the Setup Instructions will list the installation instructions for the
+videoconferencing service Zoom.
+If you use a different videoconferencing service,
+you can edit the file in `_includes/install_instructions/videoconferencing.html`
+to include the relevant installation instructions.
 
 ## Home Page: Schedule and Syllabus
 

--- a/_includes/install_instructions/videoconferencing.html
+++ b/_includes/install_instructions/videoconferencing.html
@@ -1,0 +1,43 @@
+
+<h3 id="videoconferencing">Install the videoconferencing client</h3>
+
+{% comment %}
+Replace the paragraph below with the relevant installation instructions
+if you do not use Zoom
+{% endcomment %}
+<p>
+  If you haven't used Zoom before, go to the
+  <a href="https://zoom.us/download">official website</a>
+  to download and install the Zoom client for your computer.
+</p>
+
+
+<h4>Set up your workspace</h4>
+
+<p>
+  Like other Carpentries workshops,
+  you will be learning by "coding along" with the Instructors.
+  To do this, you will need to have both the window for the tool
+  you will be learning about (a terminal, RStudio, your web browser, etc..)
+  and the window for the Zoom video conference client open.
+  In order to see both at once,
+  we recommend using one of the following set up options:
+  <ul>
+    <li><strong>Two monitors:</strong> If you have two monitors,
+      plan to have your terminal up on one monitor and
+      the video conferencing software on the other.</li>
+    <li><strong>Two devices:</strong> If you don't have two monitors,
+      do you have another device (tablet, smartphone) with a medium to large
+      sized screen? If so, try using the smaller device as your video
+      conference connection and your larger device (laptop or desktop)
+      to follow along with Make commands.</li>
+    <li><strong>Divide your screen:</strong> If you only have one device
+      and one screen, practice having two windows
+      (the video conference program and one of the tools you will be using
+      at the workshop) open together.
+      How can you best fit both on your screen?
+      Will it work better for you to toggle between them
+      using a keyboard shortcut?
+      Try it out in advance to decide what will work best for you.</li>
+  </ul>
+</p>

--- a/index.md
+++ b/index.md
@@ -395,7 +395,7 @@ If you do not use Zoom for your online workshop, edit the file
 `_includes/install_instructions/videoconferencing.html`
 to include the relevant installation instrucctions.
 {% endcomment %}
-{% if page.address == "online" %}
+{% if online != "false" %}
 {% include install_instructions/videoconferencing.html %}
 {% endif %}
 

--- a/index.md
+++ b/index.md
@@ -385,6 +385,25 @@ please preview your site before committing, and make sure to run
   <a href = "{{site.swc_github}}/workshop-template/wiki/Configuration-Problems-and-Solutions">Configuration Problems and Solutions wiki page</a>.
 </p>
 
+{% comment %}
+For online workshops, the section below provides:
+- installation instructions for the Zoom client
+- recommendations for setting up Learners' workspace so they can follow along
+  the instructions and the videoconferencing
+
+If you do not use Zoom for your online workshop, edit the file
+`_includes/install_instructions/videoconferencing.html`
+to include the relevant installation instrucctions.
+{% endcomment %}
+{% if page.address == "online" %}
+{% include install_instructions/videoconferencing.html %}
+{% endif %}
+
+{% comment %}
+These are the installation instructions for the tools used
+during the workshop.
+{% endcomment %}
+
 {% if site.carpentry == "swc" %}
 {% include swc/setup.html %}
 {% elsif site.carpentry == "dc" %}


### PR DESCRIPTION
Here is a first pass at adding installation instructions for a videoconferencing client if the workshop is online.

By default, if the variable `address` is set to `"online"`, then the Zoom installation instructions are provided. If a different service is used, the Instructors would need to edit the file in `_includes/install_instructions/videoconferencing.html` to include the relevant instructions for the tool they use.

The PR also includes the instructions that Sarah had included on how to set up your workspace to see both the videoconferencing and the tool being taught to follow along. 

Feedback and comments welcomed.

CC: @sstevens2 and @sheraaronhurt
