### PR TITLE
show R & Python setup instructions if site.flavor is FIXME

### DIFF
--- a/_includes/swc/setup.html
+++ b/_includes/swc/setup.html
@@ -7,9 +7,9 @@
 {% include install_instructions/git.html %}
 {% include install_instructions/editor.html %}
 
-{% if site.flavor == "r" %}
+{% if site.flavor == "r" or site.flavor == "FIXME" %}
 {% include install_instructions/r.html %}
-{% elsif site.flavor == "python" %}
+{% elsif site.flavor == "python" or site.flavor == "FIXME" %}
 {% include install_instructions/python.html %}
 {% else %}
 {% include warning-flavor.html %}


### PR DESCRIPTION
as reported by Mike Renfro on Slack, the instructions at https://swcarpentry.github.io/python-novice-inflammation/setup/ point learners to the workshop template page for detailed instructions on installing Python, but right now the built page doesn't show Python (or R) installation instructions.

This change will result in instructions for both Python and R being included in https://carpentries.github.io/workshop-template and, subsequently, any other workshop webpage where `site.flavor` is still set to "FIXME".