### PR TITLE
Remove shebang from getsql.sh

### DIFF
--- a/getsql.sh
+++ b/getsql.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 set -euo pipefail
 
 if command -v apt-get >/dev/null 2>&1 ; then


### PR DESCRIPTION
`/bin/bash` may not be available in some configurations but `bash` may exist in the user's `$PATH`.

This affects NixOS, a few BSD variants and some minimalistic docker images.

For additional compatibility, [*strict*er arguments](https://fieldnotes.tech/how-to-shell-for-compatible-makefiles/) could also be considered.