### PR TITLE
Implement who can attend

### DIFF
--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -222,6 +222,20 @@ you can add `{% raw %}{% include install_instructions/<filename.html> %}{% endra
 where `<filename.html>` needs to be replaced by one of the files
 in the `_includes/install_instructions` folder.
 
+## Homepage: who can attend?
+
+If you want to specify who can attend the workshop you are advertising,
+there is a commented-out section in `index.md` that you can use to
+inform workshop website visitors of who can attend the event.
+You may want to specify that only members of your university,
+department, etc. can attend or that the event is open to the public.
+We don't provide templated text for this as each situation is different.
+We do provide a section, called "Who can attend?" for you to specify this
+information.
+
+To use it, move the {% raw %}{% endcomment %}{% endraw %} line above the
+`<p>` tag marking the beginning of this section and edit the paragraph
+to reflect the attendance policy for your workshop.
 
 ## Updating the repository
 

--- a/index.md
+++ b/index.md
@@ -251,6 +251,27 @@ Display the contact email address set in the configuration file.
   refer to <a href="https://carpentries.org/workshop_faq/#what-are-the-roles-of-everyone-participating-in-a-workshop">our Workshop FAQ</a>.
 </p>
 
+{% comment %}
+WHO CAN ATTEND?
+
+If you would like to specify who can attend the workshop,
+you can use the section below.
+
+Move the 'endcomment' tag above the beginning of the following
+<p> tag to make this section visible.
+
+Edit the text to match who can attend the workshop. For instance:
+- This workshop is open to affiliates to ABC university.
+- This workshop is open to the public.
+- If you are interested in attending this workshop, contact me@example.com
+  for more information
+
+<p id="who-can-attend">
+    <strong>Who can attend?:</strong>
+    This workshop is open to ....
+</p>
+{% endcomment %}
+
 <hr/>
 
 {% comment%}


### PR DESCRIPTION
@carpentries/core-team-workshop-admin could you please review this?

I think it's difficult to come up with a templated text that will be useful given the diversity of situations. I propose here to have a paragraph (that is commented out by default) where instructors can list who can attend the workshop. What do you think?