### PR TITLE
Update workshop_ad.html

### DIFF
--- a/_includes/workshop_ad.html
+++ b/_includes/workshop_ad.html
@@ -15,7 +15,7 @@
   <div class="row">
     <div class="col-md-10 col-md-offset-1">
       {% unless site.title == "Workshop Title" or site.title == "" %}
-      <h2>{{site.title}}</h1>
+      <h1>{{site.title}}</h1>
       {% endunless %}
       <h2>{{page.venue}}</h2>
       <div class="row">


### PR DESCRIPTION
This looks like it was a bug in template with mismatched h1 vs h2 tags for the title so it was being displayed the same size as the venue.  Looks better after matching the h1 tags.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
