### PR TITLE
Update instructions for Gt for Windows 2.28.0

### DIFF
--- a/_includes/install_instructions/shell.html
+++ b/_includes/install_instructions/shell.html
@@ -26,7 +26,7 @@
               </li>
               <li>
                 <strong>
-                  From the dropdown menu select "Use the nano editor by default" and click on "Next".
+                  From the dropdown menu select "Use the nano editor by default" (NOTE: you may need to scroll <emph>up</emph> to find it) and click on "Next".
                 </strong>
               </li>
               {% comment %} Adjusting your PATH environment {% endcomment %}
@@ -58,8 +58,10 @@
 		Ensure that "Default (fast-forward or merge) is selected and click "Next"
               </li>
               <li>
-		Ensure that "Enable file system caching" and "Enable Git Credential Manager" are selected
-		and click on "Next".
+		Ensure that "Enable Git Credential Manager" is selected and click on "Next".
+              </li>
+              <li>
+		Ensure that "Enable file system caching" is selected and click on "Next".
               </li>
               {% comment %} Configuring experimental options {% endcomment %}
               <li>Click on "Install".</li>


### PR DESCRIPTION
This updates the location of NANO and splits "Ensure file system caching" and "Enable Git Credential Manager" and will fix #685 