### PR TITLE
add custom/multi-day schedule

### DIFF
--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -154,10 +154,10 @@ to include the relevant installation instructions.
 ## Home Page: Schedule
 
 By default, the template displays the typical schedule for your workshop based on
-the values of the variables set in the `_config.yml`. If you need to modify this
-schedule, you need to edit the `schedule.html` file found in the folder that
-matches the type of workshop you will be teaching (`dc`, `lc`, or `swc`) found
-in the `_includes` folder.
+the values of the variables set in the `_config.yml`. If you need to  make
+minor modifications to this schedule, you can edit the `schedule.html` file
+found in the sub-folder of the `_includes` folder that matches the type of 
+workshop you will be teaching  (`dc`, `lc`, or `swc`).
 
 If you wish to create your own custom schedule, an empty template is avaiable in
 `_includes/custom-schedule.html`. In this file, we provide the structure for a

--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -153,10 +153,23 @@ to include the relevant installation instructions.
 
 ## Home Page: Schedule
 
-To edit the section titled `Schedule` that appears on the website so that it shows
-when you are planning to teach the different episodes and lessons in your workshop,
-you need to modify the `schedule.html` file located in the appropriate workshop
-folder (`dc`, `lc` or `swc`) inside the `_includes` folder.
+By default, the template displays the typical schedule for your workshop based on
+the values of the variables set in the `_config.yml`. If you need to modify this
+schedule, you need to edit the `schedule.html` file found in the folder that
+matches the type of workshop you will be teaching (`dc`, `lc`, or `swc`) found
+in the `_includes` folder.
+
+If you wish to create your own custom schedule, an empty template is avaiable in
+`_includes/custom-schedule.html`. In this file, we provide the structure for a
+4-day workshop as it is often used for online workshops. To use the custom
+schedule instead of the one provided by default in the template, delete the
+block of code found under the "Schedule" header and replace it with
+`{% include custom-schedule.html %}`.
+
+The schedule is formatted using a table. If you would like to learn more about
+how to write tables in HTML, here is an [overview from
+Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table) and
+the [w3schools](https://www.w3schools.com/html/html_tables.asp).
 
 ## Home Page: Setup Instructions
 

--- a/_includes/custom-schedule.html
+++ b/_includes/custom-schedule.html
@@ -1,0 +1,72 @@
+<div class="row">        <!-- first two days -->
+  <div class="col-md-6"> <!-- left column -->
+    <h3>Day 1</h3>
+    <table class="table table-striped">
+      <tr>               <!-- row 1   -->
+        <td>Before starting</td>
+        <td><a href="{{ site.pre_survey }}{{ site.github.project_title }}" target="_blank">Pre-workshop survey</a></td>
+      </tr>
+      <tr>               <!-- row 2   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 3   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+    </table>
+  </div>
+  <div class="col-md-6"> <!-- right column -->
+    <h3>Day 2</h3>
+    <table class="table table-striped">
+      <tr>               <!-- row 1   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 2   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 3   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+    </table>
+  </div>
+</div>
+<div class="row">        <!-- days 3 and 4 -->
+  <div class="col-md-6"> <!-- left column -->
+    <h3>Day 3</h3>
+    <table class="table table-striped">
+      <tr>               <!-- row 1   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 2   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 3   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+    </table>
+  </div>
+  <div class="col-md-6"> <!-- right column -->
+    <h3>Day 4</h3>
+    <table class="table table-striped">
+      <tr>               <!-- row 1   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 2   -->
+        <td></td>        <!-- time    -->
+        <td></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 3   -->
+        <td>End</td>
+        <td><a href="{{ site.post_survey }}{{ site.github.project_title }}" target="_blank">Post-workshop survey</a></td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/index.md
+++ b/index.md
@@ -328,10 +328,25 @@ SURVEYS - DO NOT EDIT SURVEY LINKS
 {% comment %}
 SCHEDULE
 
-Show the workshop's schedule.  Edit the items and times in the table
-to match your plans.  You may also want to change 'Day 1' and 'Day
-2' to be actual dates or days of the week.
+Show the workshop's schedule.
+
+Small changes to the schedule can be done by modifying the
+`schedule.html` found in the `_includes` folder for your
+workshop type (`swc`, `lc`, or `dc`). Edit the items and
+times in the table to match your plans. You may also want to
+change 'Day 1' and 'Day 2' to be actual dates or days of the
+week.
+
+For larger changes, a blank template for a 4-day workshop
+(useful for online teaching for instance) can be found in
+`_includes/custom-schedule.html`. Add the times, and what
+you will be teaching to this file. You may also want to add
+rows to the table if you wish to break down the schedule
+further. To use this custom schedule here, replace the block
+of code below the Schedule `<h2>` header below with
+`{% include custom-schedule.html %}`.
 {% endcomment %}
+
 <h2 id="schedule">Schedule</h2>
 
 {% if site.carpentry == "swc" %}

--- a/index.md
+++ b/index.md
@@ -330,7 +330,7 @@ SCHEDULE
 
 Show the workshop's schedule.
 
-Small changes to the schedule can be done by modifying the
+Small changes to the schedule can be made by modifying the
 `schedule.html` found in the `_includes` folder for your
 workshop type (`swc`, `lc`, or `dc`). Edit the items and
 times in the table to match your plans. You may also want to


### PR DESCRIPTION
Online workshops often require more flexible schedules.
This PR introduces the possibility for instructors to create their own custom schedule when editing the existing templates gets too complicated.
