### PR TITLE
fix: close <p> tags in accessibility

### DIFF
--- a/index.md
+++ b/index.md
@@ -213,7 +213,9 @@ special instructions.
   you (e.g. sign-language interpreters, lactation facilities) please
   get in touch (using contact details below) and we will
   attempt to provide them.
+</p>
 {% else %}
+<p>
   We are dedicated to providing a positive and accessible learning environment for all. Please
   notify the instructors in advance of the workshop if you require any accommodations or if there is
   anything we can do to make this workshop more accessible to you.


### PR DESCRIPTION
Unbalanced `<p>` tags in Liquid /Jekyll `if` statement stopping `{% include %}` of markdown files rendering correctly.

