### PR TITLE
fix: extra p tag from pull request #707

### DIFF
--- a/index.md
+++ b/index.md
@@ -215,7 +215,6 @@ special instructions.
   attempt to provide them.
 </p>
 {% else %}
-<p>
   We are dedicated to providing a positive and accessible learning environment for all. Please
   notify the instructors in advance of the workshop if you require any accommodations or if there is
   anything we can do to make this workshop more accessible to you.


### PR DESCRIPTION
Apologies, an extra `<p>` tag was included in https://github.com/carpentries/workshop-template/pull/707 which causes the same kind of unbalanced tags if the workshop is marked as `online`.

When rendered the matching tags are easier to see.

#### Not Online

```html
<p id="accessibility">
  <strong>Accessibility:</strong>
  We are committed to making this workshop
  accessible to everybody. The workshop organizers have checked that:
</p>
<ul>
  <li>The room is wheelchair / scooter accessible.</li>
  <li>Accessible restrooms are available.</li>
</ul>
<p>
  Materials will be provided in advance of the workshop and
  large-print handouts are available if needed by notifying the
  organizers in advance.  If we can help making learning easier for
  you (e.g. sign-language interpreters, lactation facilities) please
  get in touch (using contact details below) and we will
  attempt to provide them.
</p>
```

#### Online

```html
<p id="accessibility">
  <strong>Accessibility:</strong>
  We are dedicated to providing a positive and accessible learning environment for all. Please
  notify the instructors in advance of the workshop if you require any accommodations or if there is
  anything we can do to make this workshop more accessible to you.
</p>
```