### PR TITLE
Adjust Requirements for online workshops

### DIFF
--- a/index.md
+++ b/index.md
@@ -186,8 +186,15 @@ SPECIAL REQUIREMENTS
 Modify the block below if there are any special requirements.
 {% endcomment %}
 <p id="requirements">
-  <strong>Requirements:</strong> Participants must bring a laptop with a
-  Mac, Linux, or Windows operating system (not a tablet, Chromebook, etc.) that they have administrative privileges on. They should have a few specific software packages installed (listed <a href="#setup">below</a>).
+  <strong>Requirements:</strong>
+  {% if online == "false" %}
+    Participants must bring a laptop with a
+    Mac, Linux, or Windows operating system (not a tablet, Chromebook, etc.) that they have administrative privileges on.
+  {% else %}
+    Participants must have access to a computer with a
+    Mac, Linux, or Windows operating system (not a tablet, Chromebook, etc.) that they have administrative privileges on.
+  {% endif %}
+  They should have a few specific software packages installed (listed <a href="#setup">below</a>).
 </p>
 
 {% comment %}


### PR DESCRIPTION
Just a small modification to make the `Requirements` section in the introduction work better for online workshops. For online workshops, I think it's enough to change

- "bring" → "have access to"
- "laptop" → "computer" 

For readability, I still opted for not adding the if-else logic in the middle of the sentence, but rather keep whole sentences. Let me know if you disagree, I don't have a strong opinion on this :)