### PR TITLE
remove suggested alternatives to nano

### DIFF
--- a/_includes/install_instructions/editor.html
+++ b/_includes/install_instructions/editor.html
@@ -25,14 +25,6 @@
           nano is a basic editor and the default that instructors use in the workshop.
           It is installed along with Git.
         </p>
-        <p>
-          Others editors that you can use are
-          <a href="https://notepad-plus-plus.org/">Notepad++</a> or
-          <a href="https://www.sublimetext.com/">Sublime Text</a>.
-          <strong>Be aware that you must
-            add its installation directory to your system path.</strong>
-          Please ask your instructor to help you do this.
-        </p>
       </article>
       <article role="tabpanel" class="tab-pane" id="editor-macos">
         <p>
@@ -47,22 +39,11 @@
         <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/9LQhwETCdwY?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
         </div>
         </div>
-        <p>
-          Others editors that you can use are
-          <a href="https://www.barebones.com/products/bbedit/">BBEdit</a> or
-          <a href="https://www.sublimetext.com/">Sublime Text</a>.
-        </p>
       </article>
       <article role="tabpanel" class="tab-pane" id="editor-linux">
         <p>
           nano is a basic editor and the default that instructors use in the workshop.
           It should be pre-installed.
-        </p>
-        <p>
-          Others editors that you can use are
-          <a href="https://wiki.gnome.org/Apps/Gedit">Gedit</a>,
-          <a href="https://kate-editor.org/">Kate</a> or
-          <a href="https://www.sublimetext.com/">Sublime Text</a>.
         </p>
       </article>
     </div>


### PR DESCRIPTION
This removes installation instructions for alternative text editors to _nano_.

The Software Carpentry Shell & Git lessons both include callouts discussing alternative text editors, and the Library Carpentry Shell lesson doesn't make much mention of text editors*, so I think this is a safe change to make. 

\* I will work up a PR on that lesson to address this, as I think it's an important point to mention if only in passing...