### PR TITLE
Update intro.html

### DIFF
--- a/_includes/lc/intro.html
+++ b/_includes/lc/intro.html
@@ -14,6 +14,6 @@
     Library Carpentry introduces you to the fundamentals of computing
     and provides you with a platform for further self-directed learning.
     For more information on what we teach and why, please see our paper
-    "<a href="https://doi.org/10.18352/lq.10176">Library Carpentry: software skills training for library professionals</a>".
+    "<a href="https://sro.sussex.ac.uk/id/eprint/65119/" target="_blank" rel="noopener noreferrer">Library Carpentry: software skills training for library professionals</a>".
   </em>
 </p>


### PR DESCRIPTION
Proposed link:
https://sro.sussex.ac.uk/id/eprint/65119/

Current (404/broken) link:
https://doi.org/10.18352/lq.10176
or, https://www.liberquarterly.eu/article/10.18352/lq.10176

Details:
liberquarterly.eu may have been suspended due to Brexit according to https://whois.eurid.eu/en/search/?domain=liberquarterly.eu

