### PR TITLE
added slug naming convention for online workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ create a workshop website.
     This name should have the form `YYYY-MM-DD-site`,
     e.g., `2016-12-01-miskatonic`,
     where `YYYY-MM-DD` is the start date of the workshop.
+    If your workshop is held online, then the respository name should have `-online` in the end.
+    e.g., `2016-12-01-miskatonic-online`
 
 5.  Make sure the repository is public, leave "Include all branches" unchecked, and click
 on "Create repository from template".


### PR DESCRIPTION
According to FAQ For Workshop Coordination (https://carpentries.org/workshop_faq/#what-is-a-slug-and-how-should-i-use-it-to-name-my-workshop-website), naming convention for online workshop should have "-online" at the end of the slug of the repository. This change will make the guideline in README consistent with the FAQ.
