### PR TITLE
add vendor directory to exclude in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -116,6 +116,7 @@ defaults:
 
 # Files and directories that are not to be copied.
 exclude:
+  - vendor
   - Makefile
   - bin/
   - .Rproj.user/


### PR DESCRIPTION
This fixes a bug with building the template in local (user-access only) mode. By default (on Fedora 33) running `make serve` asks the user for a sudo password. If the user chooses to install locally instead (as suggested by the install script):

    bundle install --path vendor/bundle
    make serve

you'll get errors because Jekyll is trying to also host the `vendor` directory. Adding `vendor` to the `exclude` list in `_config.yml` fixes this issue. This PR does exactly that.