### PR TITLE
Support pilot workshops

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,14 +10,14 @@
 #  dc: Data Carpentry
 #  lc: Library Carpentry
 #  cp: Carpentries (to use for instructor training for instance)
-#  incubator: for Carpentries Incubator lesson pilot workshops
+#  pilot: for workshops piloting a new lesson (e.g. in The Carpentries Incubator)
 # Note that for regular workshops, you should use:
 #  https://github.com/carpentries/workshop-template
 # and for instructor training events you should use:
 #  https://github.com/carpentries/training-template
-# When setting this field to "incubator", please uncomment the
-# lesson_site, pilot_pre_survey, and pilot_post_survey
-# lines further down this file and add the URL to the Incubator lesson site.
+# When setting this field to "pilot", please uncomment the
+# pilot_lesson_site, pilot_pre_survey, and pilot_post_survey
+# lines further down this file and add the URL to the relevant lesson site.
 carpentry: "swc"
 
 # This option is currently only needed for
@@ -49,17 +49,19 @@ flavor: "FIXME"
 # https://github.com/carpentries/workshop-template#creating-extra-pages
 title: "Workshop Title"
 
-# lesson_site, pilot_pre_survey, and pilot_post_survey
-# are only relevant for Carpentries Incubator lesson pilots.
-
+#------------------------------------------------------------
+# Pilot workshop settings (only relevant for lesson pilots).
+#
 # For a lesson pilot, uncomment the line below and add the URL of the lesson site.
-# lesson_site: "put the URL of your Incubator lesson pages here"
-
+# pilot_lesson_site: "put the URL of the lesson being piloted here"
+#
 # For a lesson pilot, uncomment the line below and add the URL of your pre-workshop survey
 # pilot_pre_survey: "put the URL of your pre-workshop survey here"
-
+#
 # For a lesson pilot, uncomment the line below and add the URL of your post-workshop survey
 # pilot_post_survey: "put the URL of your post-workshop survey here"
+#
+#------------------------------------------------------------
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).

--- a/_config.yml
+++ b/_config.yml
@@ -10,10 +10,14 @@
 #  dc: Data Carpentry
 #  lc: Library Carpentry
 #  cp: Carpentries (to use for instructor training for instance)
+#  incubator: for Carpentries Incubator lesson pilot workshops
 # Note that for regular workshops, you should use:
 #  https://github.com/carpentries/workshop-template
 # and for instructor training events you should use:
 #  https://github.com/carpentries/training-template
+# When setting this field to "incubator", please uncomment the
+# lesson_site, pilot_pre_survey, and pilot_post_survey
+# lines further down this file and add the URL to the Incubator lesson site.
 carpentry: "swc"
 
 # This option is currently only needed for
@@ -45,6 +49,17 @@ flavor: "FIXME"
 # https://github.com/carpentries/workshop-template#creating-extra-pages
 title: "Workshop Title"
 
+# lesson_site, pilot_pre_survey, and pilot_post_survey
+# are only relevant for Carpentries Incubator lesson pilots.
+
+# For a lesson pilot, uncomment the line below and add the URL of the lesson site.
+# lesson_site: "put the URL of your Incubator lesson pages here"
+
+# For a lesson pilot, uncomment the line below and add the URL of your pre-workshop survey
+# pilot_pre_survey: "put the URL of your pre-workshop survey here"
+
+# For a lesson pilot, uncomment the line below and add the URL of your post-workshop survey
+# pilot_post_survey: "put the URL of your post-workshop survey here"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).
@@ -71,6 +86,7 @@ carpentries_site: "https://carpentries.org/"
 dc_site: "https://datacarpentry.org"
 example_repo: "https://github.com/carpentries/lesson-example"
 example_site: "https://carpentries.github.io/lesson-example"
+incubator: "https://github.com/carpentries-incubator/"
 lc_site: "https://librarycarpentry.org/"
 swc_github: "https://github.com/swcarpentry"
 swc_pages: "https://swcarpentry.github.io"

--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -20,6 +20,7 @@ configure some site-wide variables and make the site function correctly:
     - `"lc"` for Library Carpentry workshops, and
     - `"cp"` for general Carpentries events such as instructor trainings (for which you should use
       <https://github.com/carpentries/training-template> as the website template).
+    - `"incubator"` for workshops piloting a lesson in The Carpentries Incubator.
 * `curriculum` - to tell us which curriculum is being taught.
   At the moment, applicable to Software and Data Carpentry workshops only.
   Possible values are:
@@ -32,6 +33,13 @@ configure some site-wide variables and make the site function correctly:
   it will appear in the "jumbotron" (the gray box at the top of the page). This variable is also
   used for the title of the extra pages. More information about extra pages are [available in the
   README](https://github.com/carpentries/workshop-template#creating-extra-pages).
+
+For lesson pilot workshops, you should uncomment the following three fields in
+`_config.yml`:
+
+* `lesson_site` - the URL of the lesson pages that will be taught at the workshop.
+* `pilot_pre_survey` - the URL of the pre-workshop survey you have prepared for the pilot workshop. (The standard Carpentries pre- and post-workshop surveys should not be used for pilot workshops.)
+* `pilot_post_survey` - the URL of the post-workshop survey you have prepared for the pilot workshop.
 
 For example, if the URL for the repository is `https://github.com/gvwilson/2015-07-01-miskatonic`,
 the URL for the website will be `http://gvwilson.github.io/2015-07-01-miskatonic`.
@@ -156,7 +164,7 @@ to include the relevant installation instructions.
 By default, the template displays the typical schedule for your workshop based on
 the values of the variables set in the `_config.yml`. If you need to  make
 minor modifications to this schedule, you can edit the `schedule.html` file
-found in the sub-folder of the `_includes` folder that matches the type of 
+found in the sub-folder of the `_includes` folder that matches the type of
 workshop you will be teaching  (`dc`, `lc`, or `swc`).
 
 If you wish to create your own custom schedule, an empty template is available in
@@ -170,6 +178,12 @@ The schedule is formatted using a table. If you would like to learn more about
 how to write tables in HTML, here is an [overview from
 Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table) and
 the [w3schools](https://www.w3schools.com/html/html_tables.asp).
+
+For pilot workshops, some placeholder text including a link to the lesson homepage
+will be displayed instead of a schedule table.
+The lesson homepage will contain estimated timings for teaching the lesson.
+Use the approach described above for `_includes/custome-schedule.html`
+if you would like to create a schedule table to replace this text.
 
 ## Home Page: Setup Instructions
 

--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -20,7 +20,7 @@ configure some site-wide variables and make the site function correctly:
     - `"lc"` for Library Carpentry workshops, and
     - `"cp"` for general Carpentries events such as instructor trainings (for which you should use
       <https://github.com/carpentries/training-template> as the website template).
-    - `"incubator"` for workshops piloting a lesson in The Carpentries Incubator.
+    - `"pilot"` for workshops piloting a new lesson (e.g. in The Carpentries Incubator).
 * `curriculum` - to tell us which curriculum is being taught.
   At the moment, applicable to Software and Data Carpentry workshops only.
   Possible values are:
@@ -37,7 +37,7 @@ configure some site-wide variables and make the site function correctly:
 For lesson pilot workshops, you should uncomment the following three fields in
 `_config.yml`:
 
-* `lesson_site` - the URL of the lesson pages that will be taught at the workshop.
+* `pilot_lesson_site` - the URL of the lesson pages that will be taught at the workshop.
 * `pilot_pre_survey` - the URL of the pre-workshop survey you have prepared for the pilot workshop. (The standard Carpentries pre- and post-workshop surveys should not be used for pilot workshops.)
 * `pilot_post_survey` - the URL of the post-workshop survey you have prepared for the pilot workshop.
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -32,6 +32,10 @@
       <a href="{{ site.carpentries_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/cp-logo-blue.svg %}" alt="The Carpentries logo" />
       </a>
+      {% elsif site.carpentry == "incubator" %}
+      <a href="{{ site.community_lessons_page }}" class="pull-left">
+        <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}" alt="The Carpentries Incubator logo" />
+      </a>
       {% endif %}
 
       {% comment %} Always show link to home page. {% endcomment %}

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -32,7 +32,7 @@
       <a href="{{ site.carpentries_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/cp-logo-blue.svg %}" alt="The Carpentries logo" />
       </a>
-      {% elsif site.carpentry == "incubator" %}
+      {% elsif site.carpentry == "pilot" %}
       <a href="{{ site.lesson_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}" alt="The Carpentries Incubator logo" />
       </a>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -33,7 +33,7 @@
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/cp-logo-blue.svg %}" alt="The Carpentries logo" />
       </a>
       {% elsif site.carpentry == "incubator" %}
-      <a href="{{ site.community_lessons_page }}" class="pull-left">
+      <a href="{{ site.lesson_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}" alt="The Carpentries Incubator logo" />
       </a>
       {% endif %}

--- a/assets/img/incubator-logo-blue.svg
+++ b/assets/img/incubator-logo-blue.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="357.76907mm"
+   height="460.09436mm"
+   viewBox="0 0 357.76907 460.09436"
+   version="1.1"
+   id="svg897"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="incubator-logo-blue.svg">
+  <defs
+     id="defs891" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="-972.08764"
+     inkscape:cy="1156.0822"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5"
+     inkscape:window-width="3840"
+     inkscape:window-height="2032"
+     inkscape:window-x="0"
+     inkscape:window-y="54"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata894">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-160.05831,126.33332)">
+    <path
+       style="display:inline;fill:#071159;fill-opacity:1;stroke:#071159;stroke-width:11;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 334.57323,-115.83321 c -10.1823,-0.0206 -20.14656,2.92683 -29.47137,6.79404 -21.51256,9.276056 -39.40832,25.033336 -54.71368,42.328286 -25.34907,28.91296 -44.08481,63.0515698 -57.64118,98.73022 -11.60906,30.85084 -19.29938,63.21552 -21.7804,96.045524 -0.58258,12.54822 -0.42578,25.16473 -0.23143,37.73911 0.67979,15.6669 2.99485,31.3468 6.99832,46.55947 5.68771,21.60963 15.35974,42.49803 30.16524,59.55815 14.36067,16.85788 33.16232,29.68218 53.88744,37.72956 22.46997,8.80639 46.71459,12.7979 70.7988,13.51206 13.0528,0.23849 26.11083,0.17952 38.99278,-1.91595 25.90361,-3.7931 51.05779,-13.52132 72.01532,-29.14566 17.38701,-12.71405 31.66774,-29.31684 42.1418,-47.96855 11.4259,-20.21002 18.63767,-42.70045 21.12084,-65.67866 0.74282,-12.01103 0.37148,-24.07262 0.40717,-36.10779 0.0815,-11.45203 -1.11533,-22.82134 -2.82342,-34.13704 -6.38051,-43.178584 -20.24282,-85.368934 -41.35731,-123.749634 -14.37072,-25.86583 -32.15683,-50.23418 -54.72302,-69.77829 -15.7017,-13.60676 -34.28741,-24.690926 -54.88319,-29.064096 -6.17765,-1.42898 -12.58252,-1.39968 -18.90271,-1.45075 z m 2.4851,3.38764 c 18.88662,-0.1142 37.02559,7.25603 52.54978,17.432996 22.05143,14.5118 39.83908,34.51528 54.66893,56.005 22.3674,32.7859998 38.24407,69.66061 48.35536,107.83097 7.35592,28.04464 11.44169,56.963924 11.71847,85.940414 0.32423,32.0055 -7.50271,64.35151 -24.26493,91.89828 -15.31895,25.40981 -38.47,46.19765 -65.76017,58.49784 -23.49293,10.66556 -49.57736,15.16205 -75.35484,14.60145 -27.54605,-0.28607 -55.45139,-4.44767 -80.79422,-15.47167 -11.69479,-5.18083 -22.89201,-11.68498 -32.61555,-19.96374 -7.77086,-6.95671 -15.34581,-14.25709 -21.29479,-22.836 -14.48427,-19.94085 -22.71632,-43.68765 -26.7249,-67.73976 -2.19434,-12.9001 -3.39319,-25.9638 -3.37954,-39.04802 -0.13858,-11.80023 -0.0978,-23.63385 1.38495,-35.3629 5.21794,-48.885314 21.15628,-96.548634 45.87355,-139.202284 14.42454,-24.58858 31.9127,-47.80058 53.95149,-66.27536 13.9853,-11.56165 30.13276,-21.437596 48.24021,-25.002706 4.42762,-0.84881 8.93553,-1.28569 13.4462,-1.30451 z"
+       id="path9034"
+       inkscape:connector-curvature="0" />
+    <g
+       style="display:inline;fill:#071159;fill-opacity:1"
+       id="g9091"
+       transform="matrix(2.7262325,0,0,2.7262325,171.43222,-454.92245)">
+      <path
+         d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
+         style="fill:#071159;fill-opacity:1;fill-rule:evenodd"
+         id="path2"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
+         style="fill:#071159;fill-opacity:1;fill-rule:evenodd"
+         id="path4"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
+         style="fill:#071159;fill-opacity:1;fill-rule:evenodd"
+         id="path6"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
+         style="fill:#071159;fill-opacity:1;fill-rule:evenodd"
+         id="path8"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/index.md
+++ b/index.md
@@ -333,7 +333,7 @@ SURVEYS - DO NOT EDIT SURVEY LINKS
 {% if site.carpentry == "pilot" %}
 <p><a href="{{ site.pilot_pre_survey }}">Pre-workshop Survey</a></p>
 <p><a href="{{ site.pilot_post_survey }}">Post-workshop Survey</a></p>
-{% elif site.pilot_pre_survey or site.pilot_post_survey %}
+{% elsif site.pilot_pre_survey or site.pilot_post_survey %}
 <div class="alert alert-danger">
 WARNING: you have defined custom pre- and/or post-survey links for
 a workshop not configured as a lesson pilot

--- a/index.md
+++ b/index.md
@@ -327,8 +327,13 @@ SURVEYS - DO NOT EDIT SURVEY LINKS
 {% endcomment %}
 <h2 id="surveys">Surveys</h2>
 <p>Please be sure to complete these surveys before and after the workshop.</p>
+{% if site.carpentry == "incubator" %}
+<p><a href="{{ site.pilot_pre_survey }}">Pre-workshop Survey</a></p>
+<p><a href="{{ site.pilot_post_survey }}">Post-workshop Survey</a></p>
+{% else %}
 <p><a href="{{ site.pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
 <p><a href="{{ site.post_survey }}{{ site.github.project_title }}">Post-workshop Survey</a></p>
+{% endif %}
 
 <hr/>
 
@@ -363,6 +368,13 @@ of code below the Schedule `<h2>` header below with
 {% include dc/schedule.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/schedule.html %}
+{% elsif site.carpentry == "incubator" %}
+The lesson taught in this workshop is being piloted and a precise schedule is yet to be established. The workshop will include regular breaks. If you would like to know the timing of these breaks in advance, please [contact the workshop organisers](#contact). For a list of lesson sections and estimated timings, [visit the lesson homepage]({{ site.lesson_site }}).
+{% comment %}
+Edit/replace the text above if you want to include a schedule table.
+See the contents of the _includes/custom_schedule.html file for an example of
+how one of these schedule tables is constructed.
+{% endcomment %}
 {% endif %}
 
 <hr/>
@@ -392,7 +404,7 @@ please preview your site before committing, and make sure to run
   Library Carpentry
   {% endif %}
   workshop,
-  you will need access to the software described below.
+  you will need access to software as described below.
   In addition, you will need an up-to-date web browser.
 </p>
 <p>
@@ -426,4 +438,8 @@ during the workshop.
 {% include dc/setup.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/setup.html %}
+{% elsif site.carpentry == "incubator" %}
+Please check the "Setup" page of
+[the lesson site]({{ site.lesson_site }}) for instructions to follow
+to obtain the software and data you will need to follow the lesson.
 {% endif %}

--- a/index.md
+++ b/index.md
@@ -333,6 +333,15 @@ SURVEYS - DO NOT EDIT SURVEY LINKS
 {% if site.carpentry == "pilot" %}
 <p><a href="{{ site.pilot_pre_survey }}">Pre-workshop Survey</a></p>
 <p><a href="{{ site.pilot_post_survey }}">Post-workshop Survey</a></p>
+{% elif site.pilot_pre_survey or site.pilot_post_survey %}
+<div class="alert alert-danger">
+WARNING: you have defined custom pre- and/or post-survey links for
+a workshop not configured as a lesson pilot
+(the value of `site` is not set to `pilot` in `_config.yml`).
+Please comment out the `pilot_pre_survey` and `pilot_post_survey` fields
+in `_config.yml` or, if this workshop is a lesson pilot,
+change the value of `carpentry` to `pilot`.
+</div>
 {% else %}
 <p><a href="{{ site.pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
 <p><a href="{{ site.post_survey }}{{ site.github.project_title }}">Post-workshop Survey</a></p>

--- a/index.md
+++ b/index.md
@@ -46,6 +46,9 @@ in a workshop request yet, please also fill in
 <a href="{{site.amy_site}}/forms/self-organised/">this workshop request form</a>
 to let us know about your workshop and our administrator may contact you if we
 need any extra information.
+If this is a pilot workshop for a lesson in The Carpentries Incubator,
+remember to uncomment the `lesson_site`, `pilot_pre_survey`, and `pilot_post_survey`
+fields in `_config.yml`
 </div>
 
 {% comment %}

--- a/index.md
+++ b/index.md
@@ -46,8 +46,8 @@ in a workshop request yet, please also fill in
 <a href="{{site.amy_site}}/forms/self-organised/">this workshop request form</a>
 to let us know about your workshop and our administrator may contact you if we
 need any extra information.
-If this is a pilot workshop for a lesson in The Carpentries Incubator,
-remember to uncomment the `lesson_site`, `pilot_pre_survey`, and `pilot_post_survey`
+If this is a pilot workshop for a new lesson,
+remember to uncomment the `pilot_lesson_site`, `pilot_pre_survey`, and `pilot_post_survey`
 fields in `_config.yml`
 </div>
 
@@ -330,7 +330,7 @@ SURVEYS - DO NOT EDIT SURVEY LINKS
 {% endcomment %}
 <h2 id="surveys">Surveys</h2>
 <p>Please be sure to complete these surveys before and after the workshop.</p>
-{% if site.carpentry == "incubator" %}
+{% if site.carpentry == "pilot" %}
 <p><a href="{{ site.pilot_pre_survey }}">Pre-workshop Survey</a></p>
 <p><a href="{{ site.pilot_post_survey }}">Post-workshop Survey</a></p>
 {% else %}
@@ -371,7 +371,7 @@ of code below the Schedule `<h2>` header below with
 {% include dc/schedule.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/schedule.html %}
-{% elsif site.carpentry == "incubator" %}
+{% elsif site.carpentry == "pilot" %}
 The lesson taught in this workshop is being piloted and a precise schedule is yet to be established. The workshop will include regular breaks. If you would like to know the timing of these breaks in advance, please [contact the workshop organisers](#contact). For a list of lesson sections and estimated timings, [visit the lesson homepage]({{ site.lesson_site }}).
 {% comment %}
 Edit/replace the text above if you want to include a schedule table.
@@ -441,7 +441,7 @@ during the workshop.
 {% include dc/setup.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/setup.html %}
-{% elsif site.carpentry == "incubator" %}
+{% elsif site.carpentry == "pilot" %}
 Please check the "Setup" page of
 [the lesson site]({{ site.lesson_site }}) for instructions to follow
 to obtain the software and data you will need to follow the lesson.


### PR DESCRIPTION
This fixes #724 by introducing support for lesson pilots in the workshop website template. A summary of the changes:

#### Changes to `_config.yml`

* mention `incubator` as a valid value for `carpentry`
* add three commented-out fields, for use only when `carpentry == "incubator"`:
    * `lesson_site`: the URL of the website for the lesson being piloted
    * `pilot_pre_survey`: for the host's pre-workshop survey URL (pilots should not use the standard Carpentries pre- and post-workshop surveys)
    * `pilot_post_survey`: for the host's post-workshop survey URL
    * add a link to the Incubator GitHub organisation

#### Changes to `index.md`

* add options for `site.carpentry == incubator` for the workshop schedule, the survey links, and the setup instructions. Add a reminder to the warning banner, to uncomment and fill in the extra fields in `_config.yml`.

#### Other changes

* update the instructions in `_extras/customization.md` to reflect the changes mentioned above.
* add the Incubator logo and include an option in `_includes/navbar.html` to display it, linking to the lesson website.