### PR TITLE
Fix R installation on Linux

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,6 +1,5 @@
 name: Website
 on:
-  workflow_dispatch: []
   push:
     branches:
       - gh-pages

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,5 +1,6 @@
 name: Website
 on:
+  workflow_dispatch: []
   push:
     branches:
       - gh-pages

--- a/_includes/install_instructions/r.html
+++ b/_includes/install_instructions/r.html
@@ -52,11 +52,13 @@
       </article>
       <article role="tabpanel" class="tab-pane" id="rstats-linux">
         <p>
-          You can download the binary files for your distribution
-          from <a href="https://cran.r-project.org/index.html">CRAN</a>. Or
-          you can use your package manager (e.g. for Debian/Ubuntu
-          run <code>sudo apt-get install r-base</code> and for Fedora run
-          <code>sudo dnf install R</code>).  Also, please install the
+          Instructions for R installation on various Linux platforms (debian,
+          fedora, redhat, and ubuntu) can be found at
+          <https://cran.r-project.org/bin/linux/>. These will instruct you to
+          use your package manager (e.g. for Fedora run
+          <code>sudo dnf install R</code> and for Debian/Ubuntu, add a ppa
+          repository and then run <code>sudo apt-get install r-base</code>).
+          Also, please install the
           <a href="https://www.rstudio.com/products/rstudio/download/#download">RStudio IDE</a>.
         </p>
       </article>


### PR DESCRIPTION
In the last couple of years, the instructions for installin R on linux
has improved significantly (read: there are now instructions!) I had a
report from a user who said that they found it challenging to figure
out how to install R on Ubuntu 16.04, so I thought it might be good for
us to point to the correct resources (especially since it's not always
clear that the R versions on apt are always out of date.