### PR TITLE
Ensure correct file for custom schedule

### DIFF
--- a/index.md
+++ b/index.md
@@ -384,7 +384,7 @@ of code below the Schedule `<h2>` header below with
 The lesson taught in this workshop is being piloted and a precise schedule is yet to be established. The workshop will include regular breaks. If you would like to know the timing of these breaks in advance, please [contact the workshop organisers](#contact). For a list of lesson sections and estimated timings, [visit the lesson homepage]({{ site.lesson_site }}).
 {% comment %}
 Edit/replace the text above if you want to include a schedule table.
-See the contents of the _includes/custom_schedule.html file for an example of
+See the contents of the _includes/custom-schedule.html file for an example of
 how one of these schedule tables is constructed.
 {% endcomment %}
 {% endif %}


### PR DESCRIPTION
Otherwise you get `Could not locate the included file` stuff happening when you use the suggested file. Also there's a weird mix of `file-name` and `file_name` in the includes but that's another story