### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ language: "FIXME"     # lowercase two-letter ISO language code such as "fr" (see
 latitude: "45"        # decimal latitude of workshop venue (use https://www.latlong.net/)
 longitude: "-1"       # decimal longitude of the workshop venue (use https://www.latlong.net)
 humandate: "FIXME"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
-humantime: "FIXME"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST<br>(7:00 am - 2:30 pm UTC)" or "9:00 am - 4:30 pm"
+humantime: "FIXME"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST (7:00 am - 2:30 pm UTC)"
 startdate: FIXME      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: FIXME        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["instructor one", "instructor two"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ language: "FIXME"     # lowercase two-letter ISO language code such as "fr" (see
 latitude: "45"        # decimal latitude of workshop venue (use https://www.latlong.net/)
 longitude: "-1"       # decimal longitude of the workshop venue (use https://www.latlong.net)
 humandate: "FIXME"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
-humantime: "FIXME"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
+humantime: "FIXME"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST<br>(7:00 am - 2:30 pm UTC)" or "9:00 am - 4:30 pm"
 startdate: FIXME      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: FIXME        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["instructor one", "instructor two"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]


### PR DESCRIPTION
Closes #739 
Being more inclusive and accessible by showing example of humantime in both local time and UTC time.
Proposals below would show up as:
9:00 am - 4:30 pm CEST
(7:00 am - 2:30 pm UTC)

**Changes:**

Proposal 1: (this PR)
humantime: "FIXME"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST<br>(7:00 am - 2:30 pm UTC)" or "9:00 am - 4:30 pm"


Proposal 2:
humantime: "FIXME"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST<br>(7:00 am - 2:30 pm UTC)"

Proposal 3:
humantime: "FIXME"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm" or preferably including local times and UTC times as "9:00 am - 4:30 pm CEST<br>(7:00 am - 2:30 pm UTC)"

Current:
humantime: "FIXME"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
