### PR TITLE
allow for pilots that are not for Incubator lessons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,13 +10,13 @@
 #  dc: Data Carpentry
 #  lc: Library Carpentry
 #  cp: Carpentries (to use for instructor training for instance)
-#  pilot: for workshops piloting a new lesson (e.g. in The Carpentries Incubator)
+#  incubator: for workshops teaching a lesson in The Carpentries Incubator
 # Note that for regular workshops, you should use:
 #  https://github.com/carpentries/workshop-template
 # and for instructor training events you should use:
 #  https://github.com/carpentries/training-template
-# When setting this field to "pilot", please uncomment the
-# pilot_lesson_site, pilot_pre_survey, and pilot_post_survey
+# When setting this field to "incubator", please uncomment the
+# incubator_lesson_site, incubator_pre_survey, and incubator_post_survey
 # lines further down this file and add the URL to the relevant lesson site.
 carpentry: "swc"
 
@@ -42,6 +42,10 @@ curriculum: "FIXME"
 # Note: this is only for Data Carpentry and SWC at this time.
 flavor: "FIXME"
 
+# If the workshop will be a lesson pilot (for a new official lesson or
+# a lesson in The Carpentries Incubator), set pilot to "true"
+pilot: false
+
 # Overall title for the Workshop.
 # This variable is used to (optionally) add a title in the "jumbotron"
 # (the grey box at the top of the page), and to the extra pages.
@@ -51,16 +55,17 @@ flavor: "FIXME"
 title: "Workshop Title"
 
 #------------------------------------------------------------
-# Pilot workshop settings (only relevant for lesson pilots).
+# Incubator workshop settings (only relevant for workshops teaching a lesson
+# in The Carpentries Incubator).
 #
-# For a lesson pilot, uncomment the line below and add the URL of the lesson site.
-# pilot_lesson_site: "put the URL of the lesson being piloted here"
+# For an Incubator workshop, uncomment the line below and add the URL of the lesson site.
+# incubator_lesson_site: "put the URL of the lesson being taught here"
 #
-# For a lesson pilot, uncomment the line below and add the URL of your pre-workshop survey
-# pilot_pre_survey: "put the URL of your pre-workshop survey here"
+# For an Incubator workshop, uncomment the line below and add the URL of your pre-workshop survey
+# incubator_pre_survey: "put the URL of your pre-workshop survey here"
 #
-# For a lesson pilot, uncomment the line below and add the URL of your post-workshop survey
-# pilot_post_survey: "put the URL of your post-workshop survey here"
+# For an Incubator workshop, uncomment the line below and add the URL of your post-workshop survey
+# incubator_post_survey: "put the URL of your post-workshop survey here"
 #
 #------------------------------------------------------------
 

--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -20,7 +20,7 @@ configure some site-wide variables and make the site function correctly:
     - `"lc"` for Library Carpentry workshops, and
     - `"cp"` for general Carpentries events such as instructor trainings (for which you should use
       <https://github.com/carpentries/training-template> as the website template).
-    - `"pilot"` for workshops piloting a new lesson (e.g. in The Carpentries Incubator).
+    - `"incubator"` for workshops teaching a lesson in The Carpentries Incubator.
 * `curriculum` - to tell us which curriculum is being taught.
   At the moment, applicable to Software and Data Carpentry workshops only.
   Possible values are:
@@ -29,17 +29,21 @@ configure some site-wide variables and make the site function correctly:
     - `"swc-inflammation"` or `"swc-gapminder"` for Software Carpentry workshops.
 * `flavor` - `"r"` or `"python"` depending on which lessons are being taught at the workshop
   (currently only for Data Carpentry and Software Carpentry workshops).
+* `pilot` - set this to `true` if the workshop will be a lesson pilot
+  (of a new official lesson or a lesson in The Carpentries Incubator).
 * `title` - overall title for the workshop. If set (i.e., different from "Workshop Title" or empty),
   it will appear in the "jumbotron" (the gray box at the top of the page). This variable is also
   used for the title of the extra pages. More information about extra pages are [available in the
   README](https://github.com/carpentries/workshop-template#creating-extra-pages).
 
-For lesson pilot workshops, you should uncomment the following three fields in
+For workshops teaching lessons in The Carpentries Incubator,
+i.e. where `carpentry` is set to `incubator`,
+you should uncomment the following three fields in
 `_config.yml`:
 
-* `pilot_lesson_site` - the URL of the lesson pages that will be taught at the workshop.
-* `pilot_pre_survey` - the URL of the pre-workshop survey you have prepared for the pilot workshop. (The standard Carpentries pre- and post-workshop surveys should not be used for pilot workshops.)
-* `pilot_post_survey` - the URL of the post-workshop survey you have prepared for the pilot workshop.
+* `incubator_lesson_site` - the URL of the lesson pages that will be taught at the workshop.
+* `incubator_pre_survey` - the URL of the pre-workshop survey you have prepared for the pilot workshop. (The standard Carpentries pre- and post-workshop surveys should not be used for Incubator workshops.)
+* `incubator_post_survey` - the URL of the post-workshop survey you have prepared for the pilot workshop.
 
 ## Site URL
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -32,8 +32,8 @@
       <a href="{{ site.carpentries_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/cp-logo-blue.svg %}" alt="The Carpentries logo" />
       </a>
-      {% elsif site.carpentry == "pilot" %}
-      <a href="{{ site.lesson_site }}" class="pull-left">
+      {% elsif site.carpentry == "incubator" %}
+      <a href="{{ site.incubator_lesson_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}" alt="The Carpentries Incubator logo" />
       </a>
       {% endif %}

--- a/index.md
+++ b/index.md
@@ -47,7 +47,9 @@ in a workshop request yet, please also fill in
 to let us know about your workshop and our administrator may contact you if we
 need any extra information.
 If this is a pilot workshop for a new lesson,
-remember to uncomment the `pilot_lesson_site`, `pilot_pre_survey`, and `pilot_post_survey`
+set the `pilot` field to `true` in `_config.yml`.
+For workshops teaching a lesson in The Carpentries Incubator,
+remember to uncomment the `incubator_lesson_site`, `incubator_pre_survey`, and `incubator_post_survey`
 fields in `_config.yml`
 </div>
 
@@ -115,6 +117,10 @@ the pitch.
 {% include dc/intro.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/intro.html %}
+{% endif %}
+
+{% if site.pilot %}
+This is a pilot workshop, testing out a lesson that is still under development. The lesson authors would appreciate any feedback you can give them about the lesson content and suggestions for how it could be further improved.
 {% endif %}
 
 {% comment %}
@@ -330,17 +336,17 @@ SURVEYS - DO NOT EDIT SURVEY LINKS
 {% endcomment %}
 <h2 id="surveys">Surveys</h2>
 <p>Please be sure to complete these surveys before and after the workshop.</p>
-{% if site.carpentry == "pilot" %}
-<p><a href="{{ site.pilot_pre_survey }}">Pre-workshop Survey</a></p>
-<p><a href="{{ site.pilot_post_survey }}">Post-workshop Survey</a></p>
-{% elsif site.pilot_pre_survey or site.pilot_post_survey %}
+{% if site.carpentry == "incubator" %}
+<p><a href="{{ site.incubator_pre_survey }}">Pre-workshop Survey</a></p>
+<p><a href="{{ site.incubator_post_survey }}">Post-workshop Survey</a></p>
+{% elsif site.incubator_pre_survey or site.incubator_post_survey %}
 <div class="alert alert-danger">
 WARNING: you have defined custom pre- and/or post-survey links for
-a workshop not configured as a lesson pilot
-(the value of `site` is not set to `pilot` in `_config.yml`).
-Please comment out the `pilot_pre_survey` and `pilot_post_survey` fields
-in `_config.yml` or, if this workshop is a lesson pilot,
-change the value of `carpentry` to `pilot`.
+a workshop not configured for The Carpentries Incubator
+(the value of `curriculum` is not set to `incubator` in `_config.yml`).
+Please comment out the `incubator_pre_survey` and `incubator_post_survey` fields
+in `_config.yml` or, if this workshop is teaching a lesson in the Incubator,
+change the value of `carpentry` to `incubator`.
 </div>
 {% else %}
 <p><a href="{{ site.pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
@@ -380,8 +386,15 @@ of code below the Schedule `<h2>` header below with
 {% include dc/schedule.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/schedule.html %}
-{% elsif site.carpentry == "pilot" %}
-The lesson taught in this workshop is being piloted and a precise schedule is yet to be established. The workshop will include regular breaks. If you would like to know the timing of these breaks in advance, please [contact the workshop organisers](#contact). For a list of lesson sections and estimated timings, [visit the lesson homepage]({{ site.lesson_site }}).
+{% elsif site.carpentry == "incubator" %}
+This workshop is teaching a lesson in [The Carpentries Incubator](https://carpentries-incubator.org/).
+Please check [the lesson homepage]({{ site.incubator_lesson_site }}) for a list of lesson sections and estimated timings.
+{% endif %}
+
+{% if site.pilot %}
+The lesson taught in this workshop is being piloted and a precise schedule is yet to be established. The workshop will include regular breaks. Please [contact the workshop organisers](#contact) if you would like more information about the planned schedule.
+{% endif %}
+
 {% comment %}
 Edit/replace the text above if you want to include a schedule table.
 See the contents of the _includes/custom-schedule.html file for an example of
@@ -450,8 +463,8 @@ during the workshop.
 {% include dc/setup.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/setup.html %}
-{% elsif site.carpentry == "pilot" %}
+{% elsif site.carpentry == "incubator" %}
 Please check the "Setup" page of
-[the lesson site]({{ site.lesson_site }}) for instructions to follow
+[the lesson site]({{ site.incubator_lesson_site }}) for instructions to follow
 to obtain the software and data you will need to follow the lesson.
 {% endif %}

--- a/index.md
+++ b/index.md
@@ -391,15 +391,14 @@ This workshop is teaching a lesson in [The Carpentries Incubator](https://carpen
 Please check [the lesson homepage]({{ site.incubator_lesson_site }}) for a list of lesson sections and estimated timings.
 {% endif %}
 
-{% if site.pilot %}
-The lesson taught in this workshop is being piloted and a precise schedule is yet to be established. The workshop will include regular breaks. Please [contact the workshop organisers](#contact) if you would like more information about the planned schedule.
-{% endif %}
-
 {% comment %}
 Edit/replace the text above if you want to include a schedule table.
 See the contents of the _includes/custom-schedule.html file for an example of
 how one of these schedule tables is constructed.
 {% endcomment %}
+
+{% if site.pilot %}
+The lesson taught in this workshop is being piloted and a precise schedule is yet to be established. The workshop will include regular breaks. Please [contact the workshop organisers](#contact) if you would like more information about the planned schedule.
 {% endif %}
 
 <hr/>


### PR DESCRIPTION
This builds on #724 by separating the configuration for a "pilot" workshop from that for a workshop teaching a lesson in The Carpentries Incubator.

With this change, the workshop organiser can specify whether the workshop is a pilot (which will introduce gentle warnings about the relative untested-ness of the lesson content), as well as whether this is teaching a lesson in the Incubator. For Incubator workshops, the egg logo will be used, and some additional text will be included about where to find info on schedule and setup instructions. 

Incubator workshops will also use their own pre- and post-workshop survey links. Official lesson pilots should be supported by the central pre- and post surveys, so do not need to have these separate URLs.