### PR TITLE
DC astro break episode3

### DIFF
--- a/_includes/dc/schedule.html
+++ b/_includes/dc/schedule.html
@@ -19,17 +19,17 @@ The schedule for the different curricula are listed here:
       </tr>
       <tr><td>Morning</td> <td> <a href="https://datacarpentry.org/astronomy-python/01-query/">Basic Queries</a></td></tr>
       <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/02-coords/">Coordinate Transformations</a></td></tr>
-      <tr><td>Afternoon</td> <td> <a href="https://datacarpentry.org/astronomy-python/03-motion/">Plotting and Pandas</a></td></tr>
-      <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/04-select/">Transform and Select</a></td></tr>
+      <tr><td>Afternoon</td> <td> <a href="https://datacarpentry.org/astronomy-python/03-transform/">Plotting and Tabular Data</a></td></tr>
+      <tr><td> </td> <td> <a href="https://datacarpentry.org/astronomy-python/04-motion/">Plotting and Pandas</a></td></tr>
     </table>
   </div>
   <div class="col-md-6">
     <h3>Day 2</h3>
     <table class="table table-striped">
-      <tr><td>Morning</td> <td> <a href="https://datacarpentry.org/astronomy-python/05-join/">Join</a></td></tr>
-      <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/06-photo/">Photometry</a></td></tr>
-      <tr><td>Afternoon</td> <td> <a href="https://datacarpentry.org/astronomy-python/06-photo/">Photometry (cont.)</a></td></tr>
-      <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/07-plot/">Visualization</a></td></tr>
+      <tr><td>Morning</td> <td> <a href="https://datacarpentry.org/astronomy-python/06-join/">Join</a></td></tr>
+      <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/05-select/">Transform and Select</a></td></tr>
+      <tr><td>Afternoon</td><td><a href="https://datacarpentry.org/astronomy-python/07-photo/">Photometry</a></td></tr>
+      <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/08-plot/">Visualization</a></td></tr>
     </table>
   </div>
 </div>

--- a/_includes/dc/schedule.html
+++ b/_includes/dc/schedule.html
@@ -26,8 +26,8 @@ The schedule for the different curricula are listed here:
   <div class="col-md-6">
     <h3>Day 2</h3>
     <table class="table table-striped">
-      <tr><td>Morning</td> <td> <a href="https://datacarpentry.org/astronomy-python/06-join/">Join</a></td></tr>
-      <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/05-select/">Transform and Select</a></td></tr>
+      <tr><td>Morning</td><td><a href="https://datacarpentry.org/astronomy-python/05-select/">Transform and Select</a></td></tr>
+      <tr><td> </td> <td> <a href="https://datacarpentry.org/astronomy-python/06-join/">Join</a></td></tr>
       <tr><td>Afternoon</td><td><a href="https://datacarpentry.org/astronomy-python/07-photo/">Photometry</a></td></tr>
       <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/08-plot/">Visualization</a></td></tr>
     </table>


### PR DESCRIPTION
We recently split episode 3 in the dc-astro curriculum into two episodes. This updates the schedule to reflect this adding of an episode and renumbering of subsequent episodes. 

I also noticed that episode 4 was on day 1 but I'm pretty sure we've ended most day 1s with episode 3 (now 3 and 4). So I moved the new episode 5 to day 2 and removed the split of the photometry episode over lunch. This matches our current timing estimates as well