### PR TITLE
Clarifies OpenSSH Library Steps

### DIFF
--- a/_includes/install_instructions/shell.html
+++ b/_includes/install_instructions/shell.html
@@ -26,7 +26,7 @@
               </li>
               <li>
                 <strong>
-                  From the dropdown menu select "Use the Nano editor by default" (NOTE: you will need to scroll <emph>up</emph> to find it) and click on "Next".
+                  From the dropdown menu, "Choosing the default editor used by Git", select "Use the Nano editor by default" (NOTE: you will need to scroll <emph>up</emph> to find it) and click on "Next".
                 </strong>
               </li>
               {% comment %} Adjusting the name of the initial branch in new repositories {% endcomment %}
@@ -46,6 +46,9 @@
                 command line and also from 3rd-party software" option.)
               </li>
               {% comment %} Choosing the SSH executable {% endcomment %}
+ 	      <li>
+	      Select "Use bundled OpenSSH".
+	      </li>
               {% comment %} Choosing HTTPS transport backend {% endcomment %}
               <li>
 		Ensure that "Use the native Windows Secure Channel Library" is selected and click on "Next".


### PR DESCRIPTION
The current Git for Windows installer (2.34.1) screen "Choosing the SSH Executable" page asks the use to select between "Use bundled OpenSSH" and "Use external OpenSSH".  The user should explicitly be directed to use select "Use bundled OpenSSH".

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
