### PR TITLE
Matches Credential Manager Step to Installer

### DIFF
--- a/_includes/install_instructions/shell.html
+++ b/_includes/install_instructions/shell.html
@@ -67,7 +67,7 @@
 		Ensure that "Default (fast-forward or merge) is selected and click "Next"
               </li>
               <li>
-		Ensure that "Git Credential Manager <strong>Core</strong>" is selected and click on "Next".
+		Ensure that "Git Credential Manager" is selected and click on "Next".
               </li>
               <li>
 		Ensure that "Enable file system caching" is selected and click on "Next".


### PR DESCRIPTION
Installer 2.34.1 does not use "GIT Credential Manager Core" emphasized in these instructions and instead asks the user to choose between "Git Credential Manager" and "None".  This PR changes the step direction to match the option label in the installer.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
