### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,7 +87,7 @@ repository: <USERNAME>/<PROJECT>
 email: "team@carpentries.org"
 
 # Sites.
-amy_site: "https://amy.carpentries.org/"
+amy_site: "https://amy.carpentries.org"
 carpentries_github: "https://github.com/carpentries"
 carpentries_pages: "https://carpentries.github.io"
 carpentries_site: "https://carpentries.org/"


### PR DESCRIPTION
amy workshop request form link has a double slash which gives a page not found. Remove trailing slash so that address for amy request form address works in index.md


