### PR TITLE
add line for COVID protocols

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,6 +18,7 @@ helper: ["helper one", "helper two"]     # boxed, comma-separated list of helper
 email: ["first@example.org","second@example.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 collaborative_notes:  # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
+covid_protocols:   # A sentence or two describing the host site's COVID protocols.  Be sure to distinguish between mandates and recommendations.
 ---
 
 {% comment %} See instructions in the comments below for how to edit specific sections of this workshop template. {% endcomment %}
@@ -328,6 +329,15 @@ available at https://codimd.carpentries.org
 We will use this <a href="{{ page.collaborative_notes }}">collaborative document</a> for chatting, taking notes, and sharing URLs and bits of code.
 </p>
 <hr/>
+{% endif %}
+
+{% comment %}
+COVID PROTOCOLS
+{% endcomment %}
+
+{% if page.covid_protocols %}
+<h2 id="covid">Covid Protocols</h2>
+<p>{{ page.covid_protocols }} </p>
 {% endif %}
 
 


### PR DESCRIPTION
This PR adds a variable for information about special COVID protocols.  This will display on the rendered page as a section immediately after the Code of Conduct section. @sheraaronhurt let me know if this looks OK to you or if you want it displayed elsewhere instead.
![image](https://user-images.githubusercontent.com/829690/176000918-420abf64-4391-468e-8450-67186b267241.png)


When setting up the website, Instructors will add it to the website in the same way the add in location, dates, instructor names, etc.  

![image](https://user-images.githubusercontent.com/829690/176001254-e9e0b1b0-f4af-431b-b278-2555d4dca764.png)

