### PR TITLE
add information about Carpentries Clippings to index

### DIFF
--- a/index.md
+++ b/index.md
@@ -111,6 +111,19 @@ INTRODUCTION
 Edit the general explanatory paragraph below if you want to change
 the pitch.
 {% endcomment %}
+
+<p>
+<strong><a href="https://carpentries.org">The Carpentries</a></strong> project comprises the <a
+href="{{site.swc_site}}">Software Carpentry</a>, <a href="{{site.dc_site}}">Data Carpentry</a>, and
+<a href="{{site.lc_site}}">Library Carpentry</a> communities of Instructors, Trainers, Maintainers,
+helpers, and supporters who share a mission to teach foundational computational and data science
+skills to researchers.
+<p align="center">
+  <em>
+  <strong>Want to learn more and stay engaged with The Carpentries?</strong> Carpentries Clippings is The Carpentries' biweekly newsletter, where we share community news, community job postings, and more.
+Sign up to receive future editions and read our full archive: <a href="https://carpentries.org/newsletter/">https://carpentries.org/newsletter/</a>
+  </em>
+</p>
 {% if site.carpentry == "swc" %}
 {% include swc/intro.html %}
 {% elsif site.carpentry == "dc" %}


### PR DESCRIPTION
This will address #787

I added general information about The Carpentries (pulled from our website about page) and added the text from #787. It would look like this on a datacarpentry page: 

![image](https://user-images.githubusercontent.com/3639446/224362527-8ff50ccf-890f-470a-957e-d7ab8a2881b9.png)

Tagging @sheraaronhurt because I cannot assign her as a reviewer for some reason
