### PR TITLE
Replace direct HTTP links with HTTPS DOIs

### DIFF
--- a/_includes/dc/intro.html
+++ b/_includes/dc/intro.html
@@ -1,7 +1,7 @@
 <p>
   <a href="{{site.dc_site}}">Data Carpentry</a> develops and teaches workshops on the fundamental data skills needed to conduct
-  research. Its target audience is researchers who have little to no prior computational experience, 
-  and its lessons are domain specific, building on learners' existing knowledge to enable them to quickly 
+  research. Its target audience is researchers who have little to no prior computational experience,
+  and its lessons are domain specific, building on learners' existing knowledge to enable them to quickly
   apply skills learned to their own research.
   Participants will be encouraged to help one another
   and to apply what they have learned to their own research problems.
@@ -10,6 +10,6 @@
   <em>
     For more information on what we teach and why,
     please see our paper
-    "<a href="http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005510">Good Enough Practices for Scientific Computing</a>".
+    "<a href="https://doi.org/10.1371/journal.pcbi.1005510">Good Enough Practices for Scientific Computing</a>".
   </em>
 </p>

--- a/_includes/swc/intro.html
+++ b/_includes/swc/intro.html
@@ -13,6 +13,6 @@
   <em>
     For more information on what we teach and why,
     please see our paper
-    "<a href="http://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>".
+    "<a href="https://doi.org/10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>".
   </em>
 </p>


### PR DESCRIPTION
Fixes #790 by using `https://doi.org/...` to link to introductory articles instead of `http://journals.plos.org/...`.