### PR TITLE
add installation instructions page

### DIFF
--- a/_extras/install_instructions.md
+++ b/_extras/install_instructions.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: Installation Instructions
+permalink: /install_instructions/index.html
+tools:
+  - editor
+  - git
+  - openrefine
+  - python
+  - r
+  - shell
+  - sql
+  - videoconferencing
+---
+
+{% comment %}
+To add a new set of installation instructions to this page:
+1. Add the instructions (in HTML) as a new file in the `_includes` folder
+2. Add the name of that file, without the .html extension,
+   to the `tools` array in the YAML front matter of this page
+   (i.e. between the --- above).
+{% endcomment %}
+
+{% for tool in page.tools %}
+{% include install_instructions/{{tool}}.html %}
+{% endfor %}


### PR DESCRIPTION
As described in https://github.com/swcarpentry/shell-novice/issues/1417#issuecomment-1648264614, this adds a new page containing the installation instructions for all tools and nothing else. 

Unfortunately there does not seem to be a way to directly obtain an array of the filenames inside `_includes`, so I have had to compromise with an array defined in the page metadata. I added a comment to document this, providing instructions for anyone who needs to add a new block of instructions in the future.

If and when this is merged, I will open PRs to adjust link targets on lesson Setup pages, so that they point to this page instead of the bottom of the workshop-template landing page (with all of its various and confusing FIXME text).