### PR TITLE
Link to Accommodation Request Form

### DIFF
--- a/index.md
+++ b/index.md
@@ -231,9 +231,13 @@ special instructions.
   attempt to provide them.
 </p>
 {% else %}
-  We are dedicated to providing a positive and accessible learning environment for all. Please
-  notify the instructors in advance of the workshop if you require any accommodations or if there is
-  anything we can do to make this workshop more accessible to you.
+  We are dedicated to providing a positive and accessible learning environment for all. 
+  We do not require participants to provide documentation of disabilities or disclose any unnecessary personal information. 
+  However, we do want to help create an inclusive, accessible experience for all participants. 
+  We encourage you to share any information that would be helpful to make your Carpentries experience accessible.
+  To request an accommodation for this workshop, please fill out the 
+  <a href="https://carpentries.typeform.com/to/B2OSYaD0">accommodation request form</a>.
+  If you have questions or need assistance with the accommodation form please <a href="team@carpentries.org">email us</a>.
 </p>
 {% endif %}
 

--- a/index.md
+++ b/index.md
@@ -237,7 +237,7 @@ special instructions.
   We encourage you to share any information that would be helpful to make your Carpentries experience accessible.
   To request an accommodation for this workshop, please fill out the 
   <a href="https://carpentries.typeform.com/to/B2OSYaD0">accommodation request form</a>.
-  If you have questions or need assistance with the accommodation form please <a href="team@carpentries.org">email us</a>.
+  If you have questions or need assistance with the accommodation form please <a href="mailto:team@carpentries.org">email us</a>.
 </p>
 {% endif %}
 


### PR DESCRIPTION
Adds a link to the Accommodation Request Form. Note that this removes the instruction to email the Instructors of the workshop. I will check with @carpentries/core-team-community before merging this as I am not certain if that is the intended approach.