### PR TITLE
Improves .editorconfig compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,11 +9,11 @@ trim_trailing_whitespace = true
 indent_size = 2
 indent_style = space
 
-max_line_length = 100
 # Please keep this in sync with bin/lesson_check.py!
+max_line_length = 100
 
-trim_trailing_whitespace = false
 # keep trailing spaces in markdown - 2+ spaces are translated to a hard break (<br/>)
+trim_trailing_whitespace = false
 
 [*.r]
 max_line_length = 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,8 +8,12 @@ trim_trailing_whitespace = true
 [*.md]
 indent_size = 2
 indent_style = space
-max_line_length = 100  # Please keep this in sync with bin/lesson_check.py!
-trim_trailing_whitespace = false  # keep trailing spaces in markdown - 2+ spaces are translated to a hard break (<br/>)
+
+max_line_length = 100
+# Please keep this in sync with bin/lesson_check.py!
+
+trim_trailing_whitespace = false
+# keep trailing spaces in markdown - 2+ spaces are translated to a hard break (<br/>)
 
 [*.r]
 max_line_length = 80


### PR DESCRIPTION
My text editor (NeoVim) reports the following error when editing a workshop template:

``` 
editorconfig: invalid value for option trim_trailing_whitespace: false  # keep trailing spaces in markdown - 2+ spaces are translated to a hard break (<br/>). trim_trailing_whitespace must be either "true" or "false"
editorconfig: invalid value for option max_line_length: 100  # please keep this in sync with bin/lesson_check.py!. max_line_length must be a number or "off"
```

As per https://editorconfig.org:

> Comments should go on their own lines.

This change brings .editorconfig in line with the file format as documented.
