### PR TITLE
Fix github actions node16 issue

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -23,7 +23,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
build-website was failing due to github actions moving away from node16
![image](https://github.com/carpentries/workshop-template/assets/1226959/8b285521-837c-4d9b-ae16-5b7df2ea37ba)


Updated actions/setup-python to use the recent version that is on node20 to fix github actions breaking from using node16


