### PR TITLE
Incorporate flavor into schedule for swc

### DIFF
--- a/_includes/swc/schedule.html
+++ b/_includes/swc/schedule.html
@@ -7,9 +7,17 @@
       <tr> <td>10:30</td>  <td>Morning break</td> </tr>
       <tr> <td>11:00</td>  <td>Automating Tasks with the Unix Shell (Continued)</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
+      {% if site.flavor == "r" %}
+      <tr> <td>13:00</td>  <td>Building Programs with R</td> </tr>
+      <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>15:00</td>  <td>Building Programs with R (Continued)</td> </tr>
+      {% elsif site.flavor == "python" %}
       <tr> <td>13:00</td>  <td>Building Programs with Python</td> </tr>
       <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
       <tr> <td>15:00</td>  <td>Building Programs with Python (Continued)</td> </tr>
+      {% else %}
+      {% include warning-flavor.html %}
+      {% endif %}
       <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
       <tr> <td>16:30</td>  <td>END</td> </tr>
     </table>


### PR DESCRIPTION
Attendees at recent Instructor Training (including @ttriche) noticed that workshop websites built using `swc` as the "carpentry" variable and `r`as the "flavor" weren't correctly populating the schedule with the R materials (although the software setup was correctly bringing in R instructions). See for example: https://ttriche.github.io/2024_06_20_tim_wfh/ 

This PR is a minimal fix that adds logic to `_includes/swc/schedule.html` to enable a distinct schedule for R workshops. See screenshots below for SWC Python and SWC R schedules for day 1. 

<img width="660" alt="Screenshot showing Python schedule" src="https://github.com/carpentries/workshop-template/assets/19176319/9b844a5e-726f-4778-b4a3-ff7266950cf0">

<img width="653" alt="Screenshot showing R schedule" src="https://github.com/carpentries/workshop-template/assets/19176319/a4f99b2f-46d1-4632-89e5-85bfb58a2a4f">
