### PR TITLE
Add slug check

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -79,7 +79,6 @@ jobs:
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
-
       - name: Install system dependencies for R packages
         if: steps.check-rmd.outputs.count != 0
         run: |
@@ -97,6 +96,12 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
+
+      - name: Validate workshop website
+        # https://github.com/carpentries/styles/issues/551 is no longer relevant as styles shouldn't be used for
+        # lessons but only workshop templates. So, always run the workshop checks now.
+        run: make workshop-check
+        if: always()
 
       - name: Commit and Push
         if: ${{ github.event_name == 'push' && steps.check-rmd.outputs.count != 0 && github.ref != 'refs/heads/gh-pages'}}
@@ -118,8 +123,3 @@ jobs:
           git push origin gh-pages
           # return
           cd ..
-
-      # waiting for https://github.com/carpentries/styles/issues/551
-      # to be addressed
-      # - run: make lesson-check-all
-      #   if: always()

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ create a workshop website.
 3.  Select the owner for your new repository.
     (This will probably be you, but may instead be an organization you belong to.)
 
-4.  Choose a name for your workshop website repository.
-    This name should have the form `YYYY-MM-DD-site`,
+4.  Create a slug for your workshop website repository.
+    The slug should have the form `YYYY-MM-DD-site`,
     e.g., `2016-12-01-oomza`,
-    where `YYYY-MM-DD` is the start date of the workshop.
+    where `YYYY-MM-DD` is the start date of the workshop and 'oomza' is an example site name.
     If your workshop is held online, then the respository name should have `-online` in the end.
     e.g., `2016-12-01-oomza-online`
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ create a workshop website.
 3.  Select the owner for your new repository.
     (This will probably be you, but may instead be an organization you belong to.)
 
-4.  Create a slug for your workshop website repository.
+4.  Name your workshop website repository using the Carpentries slug format.
     The slug should have the form `YYYY-MM-DD-site`,
     e.g., `2016-12-01-oomza`,
     where `YYYY-MM-DD` is the start date of the workshop and 'oomza' is an example site name.
     If your workshop is held online, then the respository name should have `-online` in the end.
-    e.g., `2016-12-01-oomza-online`
+    e.g., `2016-12-01-oomza-online`. Your website build will fail if the name of your
+    repository does not match the valid slug format!
 
 5.  Make sure the repository is public, leave "Include all branches" unchecked, and click
 on "Create repository from template".

--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -35,6 +35,25 @@ configure some site-wide variables and make the site function correctly:
   it will appear in the "jumbotron" (the gray box at the top of the page). This variable is also
   used for the title of the extra pages. The README contains [more information about extra pages](https://github.com/carpentries/workshop-template#creating-extra-pages).
 
+### Slug Validation
+
+For workshops teaching a core or mix and match curriculum, i.e. 
+where `carpentry` is set to `swc`, `dc`, or `lc`, the website build
+will check that your repository name matches the Carpentries slug 
+format - `YYYY-MM-DD-site[-online]`, e.g. `2024-05-07-oomza-online`.
+
+**If your repository name does not match this format, the build will 
+fail, and will direct you to rename your workshop website repository 
+to a valid slug.** You will then need to commit a change to the repo 
+to rebuild the site, e.g. adding a space or other inconsequential 
+change to the `README.md`.
+
+Workshop websites using `cp` or `incubator` will go through the same
+check, but the build will not fail if the repo name does not match 
+the slug format. You will see a warning in the build output instead.
+
+### Incubator lessons
+
 For workshops teaching lessons in The Carpentries Incubator,
 i.e. where `carpentry` is set to `incubator`,
 you should uncomment the following three fields in

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -408,20 +408,29 @@ def check_slug(reporter, filename, repo_dir):
 
     carpentry = config.get('carpentry', None)
 
-    if (repo_name != "workshop-template") and carpentry in ('swc', 'dc', 'lc', 'cp'):
-        if carpentry == "cp":
-            slugfmt = "YYYY-MM-DD-ttt[-online]"
-        else:
-            slugfmt = "YYYY-MM-DD-site[-online]"
+    slugfmt = "YYYY-MM-DD-site[-online]"
+    if (repo_name != "workshop-template"):
+        if carpentry in ('swc', 'dc', 'lc'):
+            fail_msg = (
+                'Website repository name `{0}` does not match the required slug format: `{1}`. '
+                'Please rename your repository to a valid slug using the rename option in the "Settings" menu.'
+            )
 
-        fail_msg = (
-            'Website repository name `{0}` does not match the required slug format: `{1}`. '
-            'Please rename your repository to a valid slug using the rename option in the "Settings" menu.'
-        )
+            if not bool(re.match(SLUG_PATTERN, repo_name)):
+                print(fail_msg.format(repo_name, slugfmt))
+                sys.exit(1)
 
-        if not bool(re.match(SLUG_PATTERN, repo_name)):
-            print(fail_msg.format(repo_name, slugfmt))
-            sys.exit(1)
+        elif carpentry in ('cp'):
+            warn_msg = (
+                'Website repository name `{0}` does not match the suggested slug format: `{1}`. '
+                'If teaching a workshop which you are collecting surveys for or are submitting into AMY, '
+                'please rename your repository to a valid slug using the rename option in the "Settings" menu.'
+            )
+
+            reporter.check(bool(re.match(SLUG_PATTERN, repo_name)),
+                None,
+                warn_msg,
+                repo_name, slugfmt)
 
 
 def main():

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -408,7 +408,7 @@ def check_slug(reporter, filename, repo_dir):
 
     carpentry = config.get('carpentry', None)
 
-    if carpentry in ('swc', 'dc', 'lc', 'cp'):
+    if (repo_name != "workshop-template") and carpentry in ('swc', 'dc', 'lc', 'cp'):
         if carpentry == "cp":
             slugfmt = "YYYY-MM-DD-ttt[-online]"
         else:

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -401,26 +401,27 @@ def check_config(reporter, filename):
                    carpentry)
 
 
-def check_slug(reporter, repo_dir):
+def check_slug(reporter, filename, repo_dir):
     config = load_yaml(filename)
 
-    repo_name = os.path.basename(repo_dir)
+    repo_name = os.path.basename(os.path.realpath(repo_dir))
 
     carpentry = config.get('carpentry', None)
-    kind = config.get('kind', None)
-
-    if carpentry == "cp":
-        slugfmt = "YYYY-MM-DD-ttt-format"
-    else:
-        slugfmt = "YYYY-MM-DD-site-format"
-
-    fail_msg = f'Workshop website slug does not match the required `{slugfmt}`'
 
     if carpentry in ('swc', 'dc', 'lc', 'cp'):
-        reporter.check(
-            bool(re.match(SLUG_PATTERN, repo_name)),
-            fail_msg
+        if carpentry == "cp":
+            slugfmt = "YYYY-MM-DD-ttt[-online]"
+        else:
+            slugfmt = "YYYY-MM-DD-site[-online]"
+
+        fail_msg = (
+            'Website repository name `{0}` does not match the required slug format: `{1}`. '
+            'Please rename your repository to a valid slug using the rename option in the "Settings" menu.'
         )
+
+        if not bool(re.match(SLUG_PATTERN, repo_name)):
+            print(fail_msg.format(repo_name, slugfmt))
+            sys.exit(1)
 
 
 def main():
@@ -436,7 +437,9 @@ def main():
 
     reporter = Reporter()
     check_config(reporter, config_file)
-    check_slug(reporter, root_dir)
+
+    check_slug(reporter, config_file, root_dir)
+
     check_unwanted_files(root_dir, reporter)
     with open(index_file, encoding='utf-8') as reader:
         data = reader.read()

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -15,6 +15,7 @@ EMAIL_PATTERN = r'[^@]+@[^@]+\.[^@]+'
 HUMANTIME_PATTERN = r'((0?[1-9]|1[0-2]):[0-5]\d(am|pm)(-|to)(0?[1-9]|1[0-2]):[0-5]\d(am|pm))|((0?\d|1\d|2[0-3]):[0-5]\d(-|to)(0?\d|1\d|2[0-3]):[0-5]\d)'
 EVENTBRITE_PATTERN = r'\d{9,10}'
 URL_PATTERN = r'https?://.+'
+SLUG_PATTERN = r'\d{4}-\d{2}-\d{2}-[A-z0-9\-\_]+'
 
 # Defaults.
 CARPENTRIES = ("dc", "swc", "lc", "cp")
@@ -400,6 +401,28 @@ def check_config(reporter, filename):
                    carpentry)
 
 
+def check_slug(reporter, repo_dir):
+    config = load_yaml(filename)
+
+    repo_name = os.path.basename(repo_dir)
+
+    carpentry = config.get('carpentry', None)
+    kind = config.get('kind', None)
+
+    if carpentry == "cp":
+        slugfmt = "YYYY-MM-DD-ttt-format"
+    else:
+        slugfmt = "YYYY-MM-DD-site-format"
+
+    fail_msg = f'Workshop website slug does not match the required `{slugfmt}`'
+
+    if carpentry in ('swc', 'dc', 'lc', 'cp'):
+        reporter.check(
+            bool(re.match(SLUG_PATTERN, repo_name)),
+            fail_msg
+        )
+
+
 def main():
     '''Run as the main program.'''
 
@@ -413,6 +436,7 @@ def main():
 
     reporter = Reporter()
     check_config(reporter, config_file)
+    check_slug(reporter, root_dir)
     check_unwanted_files(root_dir, reporter)
     with open(index_file, encoding='utf-8') as reader:
         data = reader.read()

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -420,7 +420,7 @@ def check_slug(reporter, filename, repo_dir):
                 print(fail_msg.format(repo_name, slugfmt))
                 sys.exit(1)
 
-        elif carpentry in ('cp'):
+        elif carpentry in ('cp', 'incubator'):
             warn_msg = (
                 'Website repository name `{0}` does not match the suggested slug format: `{1}`. '
                 'If teaching a workshop which you are collecting surveys for or are submitting into AMY, '


### PR DESCRIPTION
Currently when building a workshop website, there is no check to validate a repository name as a slug. This PR adds a check that will fail if the repo name does not match `YYYY-MM-DD-[site][-format]` if the `carpentry` specified in the _config.yaml is one of our official lesson programs. This will mean the workshop website will *fail to build completely*, and the user is guided to rename their repo in the Settings menu.

When using `cp` or `incubator` as the `carpentry` option, the check will only warn about the slug as this could be an incubator lesson-based workshop.