### PR TITLE
Includes optional what3words address of the workshop venue

### DIFF
--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -162,6 +162,14 @@ The header may optionally define the following:
     this line.  Note: this value must be given as a string in double
     quotes, rather than as a number.
 
+*   `what3words` is the [what3words](https://what3words.com) address for the
+    workshop venue. What3words divides the world into 3x3m squares and assigns
+    each a unique address consisting of three words separated by dots, allowing
+    users to specify locations precisely. Depending on the venue, this can be
+    used to specify the location of e.g. the room or the building entrance.
+    Note: this value is given in the form 'one.two.three' with no leading
+    slashes and not as a URL.
+
 ### For online workshops
 
 If the workshop is online, follow the same instructions as above with the

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ country: "FIXME"      # lowercase two-letter ISO country code such as "fr" (see 
 language: "FIXME"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for the workshop
 latitude: "45"        # decimal latitude of workshop venue (use https://www.latlong.net/)
 longitude: "-1"       # decimal longitude of the workshop venue (use https://www.latlong.net)
-what3words:           # optional: what3words (https://https://what3words.com) address of the workshop venue, without leading slashes e.g. "globe.lessening.computers"
+what3words:           # optional: what3words (https://what3words.com) address of the workshop venue, without leading slashes e.g. "globe.lessening.computers"
 humandate: "FIXME"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
 humantime: "FIXME"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST (7:00 am - 2:30 pm UTC)"
 startdate: FIXME      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01

--- a/index.md
+++ b/index.md
@@ -9,7 +9,6 @@ country: "FIXME"      # lowercase two-letter ISO country code such as "fr" (see 
 language: "FIXME"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for the workshop
 latitude: "45"        # decimal latitude of workshop venue (use https://www.latlong.net/)
 longitude: "-1"       # decimal longitude of the workshop venue (use https://www.latlong.net)
-what3words:           # optional: what3words (https://what3words.com) address of the workshop venue, without leading slashes e.g. "globe.lessening.computers"
 humandate: "FIXME"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
 humantime: "FIXME"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST (7:00 am - 2:30 pm UTC)"
 startdate: FIXME      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
@@ -19,6 +18,7 @@ helper: ["helper one", "helper two"]     # boxed, comma-separated list of helper
 email: ["first@example.org","second@example.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 collaborative_notes:  # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
+what3words:           # optional: what3words (https://what3words.com) address of the workshop venue, without leading slashes e.g. "globe.lessening.computers"
 ---
 
 {% comment %} See instructions in the comments below for how to edit specific sections of this workshop template. {% endcomment %}

--- a/index.md
+++ b/index.md
@@ -9,6 +9,7 @@ country: "FIXME"      # lowercase two-letter ISO country code such as "fr" (see 
 language: "FIXME"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for the workshop
 latitude: "45"        # decimal latitude of workshop venue (use https://www.latlong.net/)
 longitude: "-1"       # decimal longitude of the workshop venue (use https://www.latlong.net)
+what3words:           # optional: what3words (https://https://what3words.com) address of the workshop venue, without leading slashes e.g. "globe.lessening.computers"
 humandate: "FIXME"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
 humantime: "FIXME"    # human-readable times for the workshop e.g., "9:00 am - 4:30 pm CEST (7:00 am - 2:30 pm UTC)"
 startdate: FIXME      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
@@ -174,6 +175,10 @@ address.
   <a href="//www.openstreetmap.org/?mlat={{page.latitude}}&mlon={{page.longitude}}&zoom=16">OpenStreetMap</a>
   or
   <a href="//maps.google.com/maps?q={{page.latitude}},{{page.longitude}}">Google Maps</a>.
+  {% if page.what3words %}
+    What3Words location:
+    <a href="https://what3words.com/{{page.what3words}}">///{{page.what3words}}</a>.
+  {%endif %}
 </p>
 {% elsif online == "true_public" %}
 <p id="where">


### PR DESCRIPTION
This change adds an optional [what3words](https://what3words.com) address field to the index page, providing organisers with another, user-friendly way of specifying the venue location.