### PR TITLE
Replaces anaconda python installation with miniforge

### DIFF
--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -13,7 +13,7 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
     research computing, and great for general-purpose programming as
     well.  Installing all of its research packages individually can be
     a bit difficult, so we recommend
-    <a href="https://www.anaconda.com/download/success">Anaconda</a>,
+    <a href="https://conda-forge.org/download/">Conda-forge</a>,
     an all-in-one installer.
   </p>
 
@@ -30,7 +30,7 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
   {% endcomment %}
   <p>
     We will teach Python using the <a href="https://jupyter.org/">Jupyter Notebook</a>,
-    a programming environment that runs in a web browser (Jupyter Notebook will be installed by Anaconda). For this to work you will need a reasonably
+    a programming environment that runs in a web browser (Jupyter Notebook will be installed by Miniforge). For this to work you will need a reasonably
     up-to-date browser. The current versions of the Chrome, Safari and
     Firefox browsers are all
     <a href="https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatibility">supported</a>
@@ -48,33 +48,73 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
     <div class="tab-content">
       <article role="tabpanel" class="tab-pane active" id="python-windows">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda for Windows installer with Python 3. (If you are not sure which version to choose, you probably want the 64-bit Graphical Installer <em>Anaconda3-...-Windows-x86_64.exe</em>)</li>
-          <li>Install Python 3 by running the Anaconda Installer, using all of the defaults for installation <em>except</em> make sure to check <strong>Add Anaconda to my PATH environment variable</strong>.</li>
+          <li>Open <a href="https://conda-forge.org/download/">https://conda-forge.org/download/</a> with your web browser.</li>
+          <li>Download the Miniforge for Windows installer</li>
+	  <li>Double click on the downloaded file (Something like, <code>Minforge3-Windows-x86_64.exe</code>)</li>
+	  <li>If you get a "Windows protected your PC" pop-up from Microsoft Defender SmartScreen, click on "More info" and select "Run anyway"</li>
+          <li>Follow through the installer using all of the defaults for installation <em>except</em> make sure to check <strong>Add Miniforge3 to my PATH environment variable</strong>.</li>
+	  {% comment %}
+	  <li>Search for the application "Miniforge Prompt", open it and run: <code>conda install jupyter</code> and click <kbd>Enter</kbd> when asked for confirmation.</li>
+	  if we want to add an icon, it can be done with:
+	  https://medium.com/@kostal91/create-a-desktop-shortcut-for-jupyterlab-on-windows-9fcabcfa0d3f - easier and more convenient using %userprofile% variable rather than users\%username%
+	  and need to update miniconda for miniforge
+	  Also, the https://pypi.org/project/start-jupyter-cm/ could be helpful.
+	  {% endcomment %}
+	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.<br>
+	    (The following steps requires using the shell. If you aren't
+            comfortable doing the installation yourself
+            stop here and request help at the workshop.)
+	  </li>
+	  <li>Search for the application "Miniforge Prompt", open it and run: <code>conda env create -f .\Downloads\swc_environment.yml</code></li>
+          <li>Close the terminal window.</li>
         </ol>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/xxQ0mzZ8UvA?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="python-macos">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda Installer with Python 3 for macOS (you can either use the Graphical or the Command Line Installer).</li>
-          <li>Install Python 3 by running the Anaconda Installer using all of the defaults for installation.</li>
+          <li>Open <a href="https://conda-forge.org/download/">https://conda-forge.org/download/</a> with your web browser.</li>
+          <li>Download the appropriate Miniforge installer for macOS<br>
+	    (The following steps requires using the shell. If you aren't
+            comfortable doing the installation yourself
+            stop here and request help at the workshop.)
+	  </li>
+          <li>
+            Open a terminal window and navigate to the directory where
+            the executable is downloaded (e.g., <code>cd ~/Downloads</code>).
+          </li>
+          <li>
+            Type <pre>bash Miniforge3-</pre> and then press
+            <kbd>Tab</kbd> to autocomplete the full file name. The name of
+            file you just downloaded should appear.
+          </li>
+          <li>
+            Press <kbd>Enter</kbd>
+            (or <kbd>Return</kbd> depending on your keyboard).
+            You will follow the text-only prompts.
+            To move through the text, press <kbd>Spacebar</kbd>.
+            Type <code>yes</code> and press enter to approve the license.
+            Press <kbd>Enter</kbd> (or <kbd>Return</kbd>)
+            to approve the default location
+            for the files.
+            Type <code>yes</code> and press
+            <kbd>Enter</kbd> (or <kbd>Return</kbd>)
+            to prepend Anaconda to your <code>PATH</code>
+            (this makes the Anaconda distribution the default Python).
+          </li>
+	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.</li>
+	  <li>On the terminal run: <code>conda env create -f ~/Downloads/swc_environment.yml</code></li>
+          <li>
+            Close the terminal window.
+          </li>
         </ol>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/TcSAln46u9U?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="python-linux">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
+          <li>Open <a href="https://conda-forge.org/download/">https://conda-forge.org/download/</a> with your web browser.</li>
+          <li>Download the appropriate Miniforge installer for Linux<br>
+	    (The following steps requires using the shell. If you aren't
+            comfortable doing the installation yourself
+            stop here and request help at the workshop.)
+	  </li>
           <li>Download the Anaconda Installer with Python 3 for Linux.<br>
             (The installation requires using the shell. If you aren't
             comfortable doing the installation yourself
@@ -103,6 +143,8 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
             to prepend Anaconda to your <code>PATH</code>
             (this makes the Anaconda distribution the default Python).
           </li>
+	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.</li>
+	  <li>Search for the application "Miniforge Prompt", open it and run: <code>conda env create -f ~/Downloads/swc_environment.yml</code></li>
           <li>
             Close the terminal window.
           </li>

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -97,8 +97,8 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
             for the files.
             Type <code>yes</code> and press
             <kbd>Enter</kbd> (or <kbd>Return</kbd>)
-            to prepend Anaconda to your <code>PATH</code>
-            (this makes the Anaconda distribution the default Python).
+            to prepend Miniforge to your <code>PATH</code>
+            (this makes the Miniforge distribution the default Python).
           </li>
 	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.</li>
 	  <li>On the terminal run: <code>conda env create -f ~/Downloads/swc_environment.yml</code></li>
@@ -115,17 +115,12 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
             comfortable doing the installation yourself
             stop here and request help at the workshop.)
 	  </li>
-          <li>Download the Anaconda Installer with Python 3 for Linux.<br>
-            (The installation requires using the shell. If you aren't
-            comfortable doing the installation yourself
-            stop here and request help at the workshop.)
-          </li>
           <li>
             Open a terminal window and navigate to the directory where
             the executable is downloaded (e.g., `cd ~/Downloads`).
           </li>
           <li>
-            Type <pre>bash Anaconda3-</pre> and then press
+            Type <pre>bash Miniforge3-</pre> and then press
             <kbd>Tab</kbd> to autocomplete the full file name. The name of
             file you just downloaded should appear.
           </li>
@@ -140,8 +135,8 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
             for the files.
             Type <code>yes</code> and press
             <kbd>Enter</kbd> (or <kbd>Return</kbd>)
-            to prepend Anaconda to your <code>PATH</code>
-            (this makes the Anaconda distribution the default Python).
+            to prepend Miniforge to your <code>PATH</code>
+            (this makes the Miniforge distribution the default Python).
           </li>
 	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.</li>
 	  <li>Search for the application "Miniforge Prompt", open it and run: <code>conda env create -f ~/Downloads/swc_environment.yml</code></li>

--- a/data/swc_environment.yml
+++ b/data/swc_environment.yml
@@ -1,0 +1,9 @@
+name: swc
+channels:
+  - conda-forge
+dependencies:
+  - ipykernel
+  - jupyer
+  - matplotlib
+  - numpy
+  - pandas

--- a/data/swc_environment.yml
+++ b/data/swc_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ipykernel
-  - jupyer
+  - jupyter
   - matplotlib
   - numpy
   - pandas


### PR DESCRIPTION
Due to the anaconda ToS changes, using [conda-forge](https://conda-forge.org/) avoids that learners may be in breach of the ToS after they leave the workshop. This has been discussed in [Carpentries #genral Slack](https://carpentries.slack.com/archives/C03LE48AY/p1723222599583199?thread_ts=1720546103.358779&cid=C03LE48AY) and a pip alternative is provided at #837.

It provides instructions to create a `swc` environment is created with the basic needs for the workshops (includes explicitly both `numpy` for the inflammation lesson and `pandas` for the gapminder).

This, however, has the added difficulty to require that learners change environment (`conda activate swc`) and start `jupyter` from the terminal and not from a launcher (as anaconda provides for Windows and macOS).

I've tried to find up a way to get jupyter installed in the base env, and provide instructions to create a shortcut, but it becomes too cumbersome, plus it would only benefit Windows users. A comment has been left there to inform future attempts.
