### PR TITLE
Fix links to RStudio

### DIFF
--- a/_includes/install_instructions/r.html
+++ b/_includes/install_instructions/r.html
@@ -5,7 +5,7 @@
     <a href="https://www.r-project.org">R</a> is a programming language
     that is especially powerful for data exploration, visualization, and
     statistical analysis. To interact with R, we use
-    <a href="https://www.rstudio.com/">RStudio</a>.
+    <a href="https://posit.co/products/open-source/rstudio/">RStudio</a>.
   </p>
 
   <div>
@@ -22,7 +22,7 @@
           <a href="https://cran.r-project.org/bin/windows/base/release.htm">this .exe file</a>
           from <a href="https://cran.r-project.org/index.html">CRAN</a>.
           Also, please install the
-          <a href="https://www.rstudio.com/products/rstudio/download/#download">RStudio IDE</a>.
+          <a href="https://posit.co/download/rstudio-desktop/">RStudio IDE</a>.
           Note that if you have separate user and admin accounts, you should run the
           installers as administrator (right-click on .exe file and select "Run as
           administrator" instead of double-clicking). Otherwise problems may occur later,

--- a/_includes/install_instructions/r.html
+++ b/_includes/install_instructions/r.html
@@ -41,7 +41,7 @@
           <a href="https://cran.r-project.org/bin/macosx/R-latest.pkg">this .pkg file</a>
           from <a href="https://cran.r-project.org/index.html">CRAN</a>.
           Also, please install the
-          <a href="https://www.rstudio.com/products/rstudio/download/#download">RStudio IDE</a>.
+          <a href="https://posit.co/download/rstudio-desktop/">RStudio IDE</a>.
         </p>
         <h4>Video Tutorial</h4>
         <div class="yt-wrapper2">
@@ -59,7 +59,7 @@
           <code>sudo dnf install R</code> and for Debian/Ubuntu, add a ppa
           repository and then run <code>sudo apt-get install r-base</code>).
           Also, please install the
-          <a href="https://www.rstudio.com/products/rstudio/download/#download">RStudio IDE</a>.
+          <a href="https://posit.co/download/rstudio-desktop/">RStudio IDE</a>.
         </p>
       </article>
     </div>


### PR DESCRIPTION
Since the company RStudio renamed to Posit, the links to the IDE have changed.