### PR TITLE
Adds other booking systems beyond eventbrite

### DIFF
--- a/_includes/booking/eventbrite.html
+++ b/_includes/booking/eventbrite.html
@@ -1,0 +1,19 @@
+{% comment %}
+EVENTBRITE
+
+This block includes the Eventbrite registration widget if
+'eventbrite' has been set in the header.  You can delete it if you
+are not using Eventbrite, or leave it in, since it will not be
+displayed if the 'eventbrite' field in the header is not set.
+{% endcomment %}
+{% if page.eventbrite %}
+<strong>Some adblockers block the registration window. If you do not see the
+  registration box below, please check your adblocker settings.</strong>
+<iframe
+  src="https://www.eventbrite.com/tickets-external?eid={{page.eventbrite}}&ref=etckt"
+  frameborder="0"
+  width="100%"
+  height="280px"
+  scrolling="auto">
+</iframe>
+{% endif %}

--- a/_includes/booking/pretix.html
+++ b/_includes/booking/pretix.html
@@ -1,0 +1,20 @@
+{% comment %}
+PRETIX.eu
+
+This block includes the pretix registration widget if
+'pretix' has been set in the header.  You can delete it if you
+are not using Pretix, or leave it in, since it will not be
+displayed if the 'pretix' field in the header is not set.
+{% endcomment %}
+{% if page.pretix %}
+<strong>Some adblockers block the registration window. If you do not see the
+  registration box below, please check your adblocker settings or visit  <a href="https://pretix.eu/{{page.pretix}}/" target="_blank">the booking website</a> directly.</strong>
+<div class="pretix-widget-compat" event="https://pretix.eu/{{page.pretix}}/" single-item-select="button"></div>
+<noscript>
+   <div class="pretix-widget">
+        <div class="pretix-widget-info-message">
+                JavaScript is disabled in your browser. To access our ticket shop without JavaScript, please <a target="_blank" rel="noopener" href="https://pretix.eu/{{page.pretix}}/">click here</a>.
+                </div>
+    </div>
+</noscript>
+{% endif %}

--- a/_includes/booking/tickettailor.html
+++ b/_includes/booking/tickettailor.html
@@ -1,0 +1,21 @@
+{% comment %}
+TICKETTAILOR
+
+This block includes the Tickettailor registration widget if
+'eventbrite' has been set in the header.  You can delete it if you
+are not using Eventbrite, or leave it in, since it will not be
+displayed if the 'eventbrite' field in the header is not set.
+{% endcomment %}
+{% if page.tickettailor %}
+<strong>Some adblockers block the registration window. If you do not see the
+  registration box below, please check your adblocker settings.</strong>
+<iframe
+  src="https://www.tickettailor.com/checkout/view-event/id/{{page.tickettailor}}/"
+  frameborder="0"
+  width="100%"
+  height="380px"
+  scrolling="auto">
+</iframe>
+{% endif %}
+
+{% comment %}

--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -53,6 +53,11 @@ online workshops.
     <link rel="stylesheet" type="text/css" href="{{ relative_root_path }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ relative_root_path }}/assets/css/lesson.css" />
 
+    {% if page.pretix %}
+    <link rel="stylesheet" type="text/css" href="https://pretix.eu/{{page.pretix}}/widget/v1.css" crossorigin>
+    <script type="text/javascript" src="https://pretix.eu/widget/v1.en.js" async crossorigin></script>
+    {% endif %}
+
     {% include favicons.html %}
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/index.md
+++ b/index.md
@@ -18,6 +18,8 @@ helper: ["helper one", "helper two"]     # boxed, comma-separated list of helper
 email: ["first@example.org","second@example.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 collaborative_notes:  # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
+tickettailor:         # Optional: url bit that points to tickettailor event "1234567/abc/1100"
+pretix:               # Optional: url bit that points to pretix event "organisation/eventid"
 what3words:           # optional: what3words (https://what3words.com) address of the workshop venue, without leading slashes e.g. "globe.lessening.computers"
 ---
 
@@ -82,6 +84,18 @@ It looks like you are setting up a website for a Software Carpentry curriculum b
 </div>
 {% endunless %}
 {% endif %}
+
+{% comment %}
+Various booking systems are available. They are shown in the config above, if they are empty none will show below.
+{% endcomment %}
+{% if page.eventbrite %}
+{% include booking/eventbrite.html %}
+{% elsif page.tickettailor %}
+{% include booking/tickettailor.html %}
+{% elsif page.pretix %}
+{% include booking/pretix.html %}
+{% endif %}
+
 
 {% comment %}
 EVENTBRITE


### PR DESCRIPTION
A year ago or so, [Eventbrite started to require a paid plan for events larger than 25 people, even if they were free](hhttps://www.eventbrite.com/l/upcoming-changes-to-eventbrite/). Last month, they seem to have [reverted that change recently](`https://www.eventbrite.com/blog/free-to-publish-events/`). However, we've found alternative platforms that fulfil our needs and some are Open Source.

The changes suggested provide two alternatives to Eventbrite: [pretix.eu](https://pretix.eu/) and [tickettailor](https://www.tickettailor.com/). To ease managing them and simplify the content on `index.md` those sections have been moved to includes like with the installation steps.

There are some bits, like with Eventbrite, that workshop organisers would benefit to know about (e.g., for pretix you've got to enable the widgets on their platform). I'm not sure where to put that type of documentation, or leave it to the person setting it up to find the way around those platforms' documentation.  That would require quite a lot of effort, and increase the difficulty to maintain it.
