### PR TITLE
Add hpcc template features

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@
 #  dc: Data Carpentry
 #  lc: Library Carpentry
 #  cp: Carpentries (to use for instructor training for instance)
+#  ucl-hpcc: UCL-RC's Introduction to HPC Incubator lesson
 #  incubator: for workshops teaching a lesson in The Carpentries Incubator
 # Note that for regular workshops, you should use:
 #  https://github.com/carpentries/workshop-template

--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,13 @@ title: "Workshop Title"
 #------------------------------------------------------------
 
 #------------------------------------------------------------
+# UCL HPCC Course settings
+#------------------------------------------------------------
+arc_website: "https://www.ucl.ac.uk/advanced-research-computing/"
+arc_education_website: "https://www.ucl.ac.uk/advanced-research-computing/education"
+hpcc_lesson_site: "http://github-pages.arc.ucl.ac.uk/hpc-intro/"
+
+#------------------------------------------------------------
 # Generic settings (should not need to change).
 #------------------------------------------------------------
 

--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,9 @@ title: "Workshop Title"
 arc_website: "https://www.ucl.ac.uk/advanced-research-computing/"
 arc_education_website: "https://www.ucl.ac.uk/advanced-research-computing/education"
 hpcc_lesson_site: "http://github-pages.arc.ucl.ac.uk/hpc-intro/"
+myriad_apply_form: "https://www.rc.ucl.ac.uk/docs/Account_Services/#apply-for-an-account"
+myriad_docs_descr: "https://www.rc.ucl.ac.uk/docs/Clusters/Myriad/"
+rc_services_docs: "https://www.rc.ucl.ac.uk/docs/"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).

--- a/_includes/booking/eventbrite.html
+++ b/_includes/booking/eventbrite.html
@@ -1,0 +1,19 @@
+{% comment %}
+EVENTBRITE
+
+This block includes the Eventbrite registration widget if
+'eventbrite' has been set in the header.  You can delete it if you
+are not using Eventbrite, or leave it in, since it will not be
+displayed if the 'eventbrite' field in the header is not set.
+{% endcomment %}
+{% if page.eventbrite %}
+<strong>Some adblockers block the registration window. If you do not see the
+  registration box below, please check your adblocker settings.</strong>
+<iframe
+  src="https://www.eventbrite.com/tickets-external?eid={{page.eventbrite}}&ref=etckt"
+  frameborder="0"
+  width="100%"
+  height="280px"
+  scrolling="auto">
+</iframe>
+{% endif %}

--- a/_includes/booking/pretix.html
+++ b/_includes/booking/pretix.html
@@ -1,0 +1,20 @@
+{% comment %}
+PRETIX.eu
+
+This block includes the pretix registration widget if
+'pretix' has been set in the header.  You can delete it if you
+are not using Pretix, or leave it in, since it will not be
+displayed if the 'pretix' field in the header is not set.
+{% endcomment %}
+{% if page.pretix %}
+<strong>Some adblockers block the registration window. If you do not see the
+  registration box below, please check your adblocker settings or visit  <a href="https://pretix.eu/{{page.pretix}}/" target="_blank">the booking website</a> directly.</strong>
+<div class="pretix-widget-compat" event="https://pretix.eu/{{page.pretix}}/" single-item-select="button"></div>
+<noscript>
+   <div class="pretix-widget">
+        <div class="pretix-widget-info-message">
+                JavaScript is disabled in your browser. To access our ticket shop without JavaScript, please <a target="_blank" rel="noopener" href="https://pretix.eu/{{page.pretix}}/">click here</a>.
+                </div>
+    </div>
+</noscript>
+{% endif %}

--- a/_includes/booking/tickettailor.html
+++ b/_includes/booking/tickettailor.html
@@ -1,0 +1,21 @@
+{% comment %}
+TICKETTAILOR
+
+This block includes the Tickettailor registration widget if
+'eventbrite' has been set in the header.  You can delete it if you
+are not using Eventbrite, or leave it in, since it will not be
+displayed if the 'eventbrite' field in the header is not set.
+{% endcomment %}
+{% if page.tickettailor %}
+<strong>Some adblockers block the registration window. If you do not see the
+  registration box below, please check your adblocker settings.</strong>
+<iframe
+  src="https://www.tickettailor.com/checkout/view-event/id/{{page.tickettailor}}/"
+  frameborder="0"
+  width="100%"
+  height="380px"
+  scrolling="auto">
+</iframe>
+{% endif %}
+
+{% comment %}

--- a/_includes/install_instructions/github.html
+++ b/_includes/install_instructions/github.html
@@ -1,0 +1,51 @@
+{% comment %}
+GitHub CLI  Setup instructions rely on Shell instructions. If you don't include
+Shell instructions as part of your workshop website, make sure to adjust
+the text below accordingly.
+{% endcomment %}
+<div id="github">
+  <h3>GitHub CLI</h3>
+  <p>
+    GitHub provides a command line interface (CLI) that we will use to simplify the authentication setup between our computer and GitHub's platform.
+  </p>
+
+  <div>
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active"><a data-os="windows" href="#github-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
+      <li role="presentation"><a data-os="macos" href="#github-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
+      <li role="presentation"><a data-os="linux" href="#github-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>
+    </ul>
+
+    <div class="tab-content">
+        <article role="tabpanel" class="tab-pane active" id="github-windows">
+            <p>
+                Proceed to install <a href="https://cli.github.com/">Github CLI</a> by downloading the installer.
+            </p>
+        </article>
+        <article role="tabpanel" class="tab-pane" id="github-macos">
+            <p>
+                The easiest way to install <a href="https://cli.github.com/">Github CLI</a> is through <a href="https://brew.sh/">homebrew</a>. First you need to install homebrew:
+                <ol>
+                    <li>Open a terminal window</li>
+                    <li><p> Type </p>
+                        <div class="org-src-container">
+                            <pre class="src src-bash">/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"</pre>
+                        </div>
+                        <p> Follow the installation prompts </p>
+                    </li>
+                    <li><p> Once homebrew is installed, you can then install Github's CLI</p>
+                        <div class="org-src-container">
+                            <pre class="src src-bash">brew install gh</pre>
+                        </div>
+                    </li>
+                </ol>
+            </p>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="github-linux">
+          <p>
+              Proceed to install <a href="https://github.com/cli/cli#linux--bsd">Github's CLI</a> following the option according to your distribution.
+          </p>
+      </article>
+    </div>
+  </div>
+</div>

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -13,7 +13,7 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
     research computing, and great for general-purpose programming as
     well.  Installing all of its research packages individually can be
     a bit difficult, so we recommend
-    <a href="https://www.anaconda.com/download/success">Anaconda</a>,
+    <a href="https://conda-forge.org/download/">Conda-forge</a>,
     an all-in-one installer.
   </p>
 
@@ -30,7 +30,7 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
   {% endcomment %}
   <p>
     We will teach Python using the <a href="https://jupyter.org/">Jupyter Notebook</a>,
-    a programming environment that runs in a web browser (Jupyter Notebook will be installed by Anaconda). For this to work you will need a reasonably
+    a programming environment that runs in a web browser (Jupyter Notebook will be installed by Miniforge). For this to work you will need a reasonably
     up-to-date browser. The current versions of the Chrome, Safari and
     Firefox browsers are all
     <a href="https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatibility">supported</a>
@@ -48,33 +48,73 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
     <div class="tab-content">
       <article role="tabpanel" class="tab-pane active" id="python-windows">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda for Windows installer with Python 3. (If you are not sure which version to choose, you probably want the 64-bit Graphical Installer <em>Anaconda3-...-Windows-x86_64.exe</em>)</li>
-          <li>Install Python 3 by running the Anaconda Installer, using all of the defaults for installation <em>except</em> make sure to check <strong>Add Anaconda to my PATH environment variable</strong>.</li>
+          <li>Open <a href="https://conda-forge.org/download/">https://conda-forge.org/download/</a> with your web browser.</li>
+          <li>Download the Miniforge for Windows installer</li>
+	  <li>Double click on the downloaded file (Something like, <code>Minforge3-Windows-x86_64.exe</code>)</li>
+	  <li>If you get a "Windows protected your PC" pop-up from Microsoft Defender SmartScreen, click on "More info" and select "Run anyway"</li>
+          <li>Follow through the installer using all of the defaults for installation <em>except</em> make sure to check <strong>Add Miniforge3 to my PATH environment variable</strong>.</li>
+	  {% comment %}
+	  <li>Search for the application "Miniforge Prompt", open it and run: <code>conda install jupyter</code> and click <kbd>Enter</kbd> when asked for confirmation.</li>
+	  if we want to add an icon, it can be done with:
+	  https://medium.com/@kostal91/create-a-desktop-shortcut-for-jupyterlab-on-windows-9fcabcfa0d3f - easier and more convenient using %userprofile% variable rather than users\%username%
+	  and need to update miniconda for miniforge
+	  Also, the https://pypi.org/project/start-jupyter-cm/ could be helpful.
+	  {% endcomment %}
+	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.<br>
+	    (The following steps requires using the shell. If you aren't
+            comfortable doing the installation yourself
+            stop here and request help at the workshop.)
+	  </li>
+	  <li>Search for the application "Miniforge Prompt", open it and run: <code>conda env create -f .\Downloads\swc_environment.yml</code></li>
+          <li>Close the terminal window.</li>
         </ol>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/xxQ0mzZ8UvA?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="python-macos">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda Installer with Python 3 for macOS (you can either use the Graphical or the Command Line Installer).</li>
-          <li>Install Python 3 by running the Anaconda Installer using all of the defaults for installation.</li>
+          <li>Open <a href="https://conda-forge.org/download/">https://conda-forge.org/download/</a> with your web browser.</li>
+          <li>Download the appropriate Miniforge installer for macOS<br>
+	    (The following steps requires using the shell. If you aren't
+            comfortable doing the installation yourself
+            stop here and request help at the workshop.)
+	  </li>
+          <li>
+            Open a terminal window and navigate to the directory where
+            the executable is downloaded (e.g., <code>cd ~/Downloads</code>).
+          </li>
+          <li>
+            Type <pre>bash Miniforge3-</pre> and then press
+            <kbd>Tab</kbd> to autocomplete the full file name. The name of
+            file you just downloaded should appear.
+          </li>
+          <li>
+            Press <kbd>Enter</kbd>
+            (or <kbd>Return</kbd> depending on your keyboard).
+            You will follow the text-only prompts.
+            To move through the text, press <kbd>Spacebar</kbd>.
+            Type <code>yes</code> and press enter to approve the license.
+            Press <kbd>Enter</kbd> (or <kbd>Return</kbd>)
+            to approve the default location
+            for the files.
+            Type <code>yes</code> and press
+            <kbd>Enter</kbd> (or <kbd>Return</kbd>)
+            to prepend Anaconda to your <code>PATH</code>
+            (this makes the Anaconda distribution the default Python).
+          </li>
+	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.</li>
+	  <li>On the terminal run: <code>conda env create -f ~/Downloads/swc_environment.yml</code></li>
+          <li>
+            Close the terminal window.
+          </li>
         </ol>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/TcSAln46u9U?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="python-linux">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
+          <li>Open <a href="https://conda-forge.org/download/">https://conda-forge.org/download/</a> with your web browser.</li>
+          <li>Download the appropriate Miniforge installer for Linux<br>
+	    (The following steps requires using the shell. If you aren't
+            comfortable doing the installation yourself
+            stop here and request help at the workshop.)
+	  </li>
           <li>Download the Anaconda Installer with Python 3 for Linux.<br>
             (The installation requires using the shell. If you aren't
             comfortable doing the installation yourself
@@ -103,6 +143,8 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
             to prepend Anaconda to your <code>PATH</code>
             (this makes the Anaconda distribution the default Python).
           </li>
+	  <li>Download the <a href="./data/swc_environment.yml" download>environment file</a>.</li>
+	  <li>Search for the application "Miniforge Prompt", open it and run: <code>conda env create -f ~/Downloads/swc_environment.yml</code></li>
           <li>
             Close the terminal window.
           </li>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -32,6 +32,10 @@
       <a href="{{ site.carpentries_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/cp-logo-blue.svg %}" alt="The Carpentries logo" />
       </a>
+      {% elsif site.carpentry == "ucl-hpcc" %}
+      <a href="{{ site.incubator_lesson_site }}" class="pull-left">
+        <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}"
+          alt="The Carpentries Incubator logo" />
       {% elsif site.carpentry == "incubator" %}
       <a href="{{ site.incubator_lesson_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ relative_root_path }}{% link /assets/img/incubator-logo-blue.svg %}" alt="The Carpentries Incubator logo" />

--- a/_includes/swc/setup.html
+++ b/_includes/swc/setup.html
@@ -5,6 +5,7 @@
 
 {% include install_instructions/shell.html %}
 {% include install_instructions/git.html %}
+{% include install_instructions/github.html %}
 {% include install_instructions/editor.html %}
 
 {% if site.flavor == "r" %}

--- a/_includes/ucl-hpcc/intro.html
+++ b/_includes/ucl-hpcc/intro.html
@@ -1,0 +1,18 @@
+<p>
+  <a href="{{site.swc_site}}">Software Carpentry</a>
+  aims to help researchers get their work done
+  in less time and with less pain
+  by teaching them basic research computing skills.
+  This hands-on workshop will cover basic concepts and tools,
+  including program design, version control, data management,
+  and task automation.
+  Participants will be encouraged to help one another
+  and to apply what they have learned to their own research problems.
+</p>
+<p align="center">
+  <em>
+    For more information on what we teach and why,
+    please see our paper
+    "<a href="https://doi.org/10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>".
+  </em>
+</p>

--- a/_includes/ucl-hpcc/intro.html
+++ b/_includes/ucl-hpcc/intro.html
@@ -1,18 +1,16 @@
 <p>
-  <a href="{{site.swc_site}}">Software Carpentry</a>
-  aims to help researchers get their work done
-  in less time and with less pain
-  by teaching them basic research computing skills.
-  This hands-on workshop will cover basic concepts and tools,
-  including program design, version control, data management,
-  and task automation.
-  Participants will be encouraged to help one another
-  and to apply what they have learned to their own research problems.
-</p>
-<p align="center">
-  <em>
-    For more information on what we teach and why,
-    please see our paper
-    "<a href="https://doi.org/10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>".
-  </em>
+  The <a href="{{site.arc_website}}">Centre for Advanced Research Computing (ARC)</a>
+  is UCL's research, innovation and service centre for the tools, practices and systems
+  that enable computational science and digital scholarship.
+  
+  We are an innovative centre with both professional services and academic missions:
+  <ul>
+    <li>We provide advanced, reliable and secure digital research infrastructure to
+      research groups in UCL and beyond.</li>
+    <li>We are a laboratory for research, teaching and innovation in compute, data
+      and software intensive research methods.</li>
+  </ul>
+
+  You can read more about what our <a href="{{site.arc_education_website}}" target="_blank">
+    Education team offers here</a>.
 </p>

--- a/_includes/ucl-hpcc/myriad-registration.html
+++ b/_includes/ucl-hpcc/myriad-registration.html
@@ -1,0 +1,43 @@
+<div id="setup-myriad">
+    <h3>Registering for an Account on Myriad</h3>
+    <p>
+        <a href="{{site.myriad_docs_descr}}" target="_blank">Myriad</a> is one of UCL's High Performance
+        Computer (HPC) clusters, and is designed for high I/O, high throughput jobs that will run within
+        a single node, rather than multi-node parallel jobs.
+
+        In this workshop, we will be working on Myriad and exploring how to interact with the filesystem,
+        submit jobs to the scheduler, and effectively request resources for your jobs.
+        But to use Myriad, you will need an account.
+    </p>
+
+    <div>
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active"><a data-has-acccount="no" href="#myriad-no-account" aria-controls="No Account"
+                    role="tab" data-toggle="tab">I do not have a Myriad account</a></li>
+            <li role="presentation"><a data-has-account="yes" href="#myriad-has-account" aria-controls="Has Account" role="tab"
+                    data-toggle="tab">I already have a Myriad account</a></li>
+        </ul>
+
+        <div class="tab-content">
+            <article role="tabpanel" class="tab-pane active" id="myriad-no-account">
+                <p>
+                    You can apply for an account on Myriad by <a href="{{site.myriad_apply_form}}" target="_blank">completing the application form.</a>
+                    <ul>
+                        <li>You will need to use your UCL user ID when you register.</li>
+                        <li>Under the "Project Name" and "Work Description" fields, state that you are requesting an account for this course.</li>
+                    </ul>
+                </p>
+                <p>
+                    You should sign up for an account no later than 2 days before the workshop.
+                    Otherwise, there will not be time to activate your account before the workshop starts.
+                </p>
+            </article>
+            <article role="tabpanel" class="tab-pane" id="myriad-has-account">
+                <p>
+                    If you already have a Myriad account, you can use that for this course.
+                    You do not need to do anything further, but you will need your login details to hand during the workshop.
+                </p>
+            </article>
+        </div>
+    </div>
+</div>

--- a/_includes/ucl-hpcc/schedule.html
+++ b/_includes/ucl-hpcc/schedule.html
@@ -1,0 +1,40 @@
+<div class="row">
+  <div class="col-md-6">
+    <h3>Day 1</h3>
+    <table class="table table-striped">
+      <tr> <td>Before</td> <td><a href="{{ site.pre_survey }}{{ site.github.project_title }}" target="_blank" rel="noopener noreferrer">Pre-workshop survey</a> </td> </tr>
+      <tr> <td>09:00</td>  <td>Automating Tasks with the Unix Shell</td> </tr>
+      <tr> <td>10:30</td>  <td>Morning break</td> </tr>
+      <tr> <td>11:00</td>  <td>Automating Tasks with the Unix Shell (Continued)</td> </tr>
+      <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
+      {% if site.flavor == "r" %}
+      <tr> <td>13:00</td>  <td>Building Programs with R</td> </tr>
+      <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>15:00</td>  <td>Building Programs with R (Continued)</td> </tr>
+      {% elsif site.flavor == "python" %}
+      <tr> <td>13:00</td>  <td>Building Programs with Python</td> </tr>
+      <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>15:00</td>  <td>Building Programs with Python (Continued)</td> </tr>
+      {% else %}
+      {% include warning-flavor.html %}
+      {% endif %}
+      <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>16:30</td>  <td>END</td> </tr>
+    </table>
+  </div>
+  <div class="col-md-6">
+    <h3>Day 2</h3>
+    <table class="table table-striped">
+      <tr> <td>09:00</td>  <td>Version Control with Git</td> </tr>
+      <tr> <td>10:30</td>  <td>Morning break</td> </tr>
+      <tr> <td>11:00</td>  <td>Version Control with Git (Continued)</td> </tr>
+      <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
+      <tr> <td>13:00</td>  <td>Managing Data with SQL</td> </tr>
+      <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>15:00</td>  <td>Managing Data with SQL (Continued)</td> </tr>
+      <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>16:30</td>  <td><a href="{{ site.post_survey }}{{ site.github.project_title }}" target="_blank" rel="noopener noreferrer">Post-workshop Survey</a></td> </tr>
+      <tr> <td>16:40</td>  <td>END</td> </tr>
+    </table>
+  </div>
+</div>

--- a/_includes/ucl-hpcc/setup.html
+++ b/_includes/ucl-hpcc/setup.html
@@ -1,29 +1,3 @@
-{% assign curricula = "swc-gapminder|swc-inflammation"  | split: "|" %}
-{% unless curricula contains site.curriculum %}
-{% include warning-curriculum.html %}
-{% endunless %}
-
 {% include install_instructions/shell.html %}
-{% include install_instructions/git.html %}
-{% include install_instructions/github.html %}
-{% include install_instructions/editor.html %}
 
-{% if site.flavor == "r" %}
-{% include install_instructions/r.html %}
-{% elsif site.flavor == "python" %}
-{% include install_instructions/python.html %}
-{% elsif site.flavor == "FIXME" %}
-{% include install_instructions/r.html %}
-{% include install_instructions/python.html %}
-{% else %}
-{% include warning-flavor.html %}
-{% endif %}
-
-{% comment %}
-The following setup instructions are commented out because Carpentries workshops
-cover the these topics less frequently. Please uncomment the lines that
-correspond to the topics covered in your workshop.
-
-{% include install_instructions/sql.html %}
-{% include install_instructions/openrefine.html %}
-{% endcomment %}
+{% include ucl-hpcc/myriad-registration.html %}

--- a/_includes/ucl-hpcc/setup.html
+++ b/_includes/ucl-hpcc/setup.html
@@ -1,0 +1,29 @@
+{% assign curricula = "swc-gapminder|swc-inflammation"  | split: "|" %}
+{% unless curricula contains site.curriculum %}
+{% include warning-curriculum.html %}
+{% endunless %}
+
+{% include install_instructions/shell.html %}
+{% include install_instructions/git.html %}
+{% include install_instructions/github.html %}
+{% include install_instructions/editor.html %}
+
+{% if site.flavor == "r" %}
+{% include install_instructions/r.html %}
+{% elsif site.flavor == "python" %}
+{% include install_instructions/python.html %}
+{% elsif site.flavor == "FIXME" %}
+{% include install_instructions/r.html %}
+{% include install_instructions/python.html %}
+{% else %}
+{% include warning-flavor.html %}
+{% endif %}
+
+{% comment %}
+The following setup instructions are commented out because Carpentries workshops
+cover the these topics less frequently. Please uncomment the lines that
+correspond to the topics covered in your workshop.
+
+{% include install_instructions/sql.html %}
+{% include install_instructions/openrefine.html %}
+{% endcomment %}

--- a/_includes/ucl-hpcc/surveys.html
+++ b/_includes/ucl-hpcc/surveys.html
@@ -1,1 +1,6 @@
-<p>UCL-specific survey links will need to go here.</p>
+<p>
+    There are currently no surveys available for this workshop.
+    <!-- We might want to create our own Feedback forms, EG through MS bookings.
+     We can then link to these from this site.
+    -->
+</p>

--- a/_includes/ucl-hpcc/surveys.html
+++ b/_includes/ucl-hpcc/surveys.html
@@ -1,0 +1,1 @@
+<p>UCL-specific survey links will need to go here.</p>

--- a/_includes/ucl-hpcc/who.html
+++ b/_includes/ucl-hpcc/who.html
@@ -1,0 +1,8 @@
+<p id="who">
+  <strong>Who:</strong>
+  The course is aimed at graduate students and other researchers.
+  <strong>
+    You don't need to have any previous knowledge of the tools
+    that will be presented at the workshop.
+  </strong>
+</p>

--- a/_includes/ucl-hpcc/who.html
+++ b/_includes/ucl-hpcc/who.html
@@ -1,8 +1,8 @@
 <p id="who">
   <strong>Who:</strong>
-  The course is aimed at graduate students and other researchers.
+  The course is aimed at graduate students and other researchers who would like to use UCL's HPC clusters to run high-throughput analysis pipelines.
   <strong>
-    You don't need to have any previous knowledge of the tools
-    that will be presented at the workshop.
+  You will need to be comfortable using the UNIX command line to interact with a machine, before you start this course.
   </strong>
+  The <a href="https://swcarpentry.github.io/shell-novice/" target="_blank">Introduction to the UNIX shell</a> Carpentries lesson is a suitable pre-requisite, and ARC typically run an instance of this course every term.
 </p>

--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -53,6 +53,11 @@ online workshops.
     <link rel="stylesheet" type="text/css" href="{{ relative_root_path }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ relative_root_path }}/assets/css/lesson.css" />
 
+    {% if page.pretix %}
+    <link rel="stylesheet" type="text/css" href="https://pretix.eu/{{page.pretix}}/widget/v1.css" crossorigin>
+    <script type="text/javascript" src="https://pretix.eu/widget/v1.en.js" async crossorigin></script>
+    {% endif %}
+
     {% include favicons.html %}
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/data/swc_environment.yml
+++ b/data/swc_environment.yml
@@ -1,0 +1,9 @@
+name: swc
+channels:
+  - conda-forge
+dependencies:
+  - ipykernel
+  - jupyer
+  - matplotlib
+  - numpy
+  - pandas

--- a/data/swc_environment.yml
+++ b/data/swc_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ipykernel
-  - jupyer
+  - jupyter
   - matplotlib
   - numpy
   - pandas

--- a/index.md
+++ b/index.md
@@ -18,6 +18,8 @@ helper: ["helper one", "helper two"]     # boxed, comma-separated list of helper
 email: ["first@example.org","second@example.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 collaborative_notes:  # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
+tickettailor:         # Optional: url bit that points to tickettailor event "1234567/abc/1100"
+pretix:               # Optional: url bit that points to pretix event "organisation/eventid"
 what3words:           # optional: what3words (https://what3words.com) address of the workshop venue, without leading slashes e.g. "globe.lessening.computers"
 ---
 
@@ -82,6 +84,18 @@ It looks like you are setting up a website for a Software Carpentry curriculum b
 </div>
 {% endunless %}
 {% endif %}
+
+{% comment %}
+Various booking systems are available. They are shown in the config above, if they are empty none will show below.
+{% endcomment %}
+{% if page.eventbrite %}
+{% include booking/eventbrite.html %}
+{% elsif page.tickettailor %}
+{% include booking/tickettailor.html %}
+{% elsif page.pretix %}
+{% include booking/pretix.html %}
+{% endif %}
+
 
 {% comment %}
 EVENTBRITE

--- a/index.md
+++ b/index.md
@@ -145,6 +145,8 @@ Sign up to receive future editions and read our full archive: <a href="https://c
 {% include dc/intro.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/intro.html %}
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/intro.html %}
 {% endif %}
 
 {% if site.pilot %}
@@ -163,6 +165,8 @@ workshop is only open to people from a particular institution.
 {% include dc/who.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/who.html %}
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/who.html %}
 {% endif %}
 
 {% comment %}
@@ -384,6 +388,8 @@ Please comment out the `incubator_pre_survey` and `incubator_post_survey` fields
 in `_config.yml` or, if this workshop is teaching a lesson in the Incubator,
 change the value of `carpentry` to `incubator`.
 </div>
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/surveys.html %}
 {% else %}
 <p><a href="{{ site.pre_survey }}{{ site.github.project_title }}">Pre-workshop Survey</a></p>
 <p><a href="{{ site.post_survey }}{{ site.github.project_title }}">Post-workshop Survey</a></p>
@@ -422,6 +428,8 @@ of code below the Schedule `<h2>` header below with
 {% include dc/schedule.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/schedule.html %}
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/schedule.html %}
 {% elsif site.carpentry == "incubator" %}
 This workshop is teaching a lesson in 
 <a href="https://carpentries-incubator.org/">The Carpentries Incubator</a>. Please check <a href="{{site.incubator_lesson_site}}">the lesson homepage</a> for a list of lesson sections and estimated timings.
@@ -494,10 +502,12 @@ during the workshop.
 
 {% if site.carpentry == "swc" %}
 {% include swc/setup.html %}
-{% elsif site.carpentry == "dc" %}
+{% elsif site.carpentry == "dc" %}f
 {% include dc/setup.html %}
 {% elsif site.carpentry == "lc" %}
 {% include lc/setup.html %}
+{% elsif site.carpentry == "ucl-hpcc" %}
+{% include ucl-hpcc/setup.html %}
 {% elsif site.carpentry == "incubator" %}
 Please check the "Setup" page of
 <a href="{{site.incubator_lesson_site}}">the lesson homepage</a> for instructions to follow


### PR DESCRIPTION
Allows us to set

`carpentry: "ucl-hpcc"`

in `_config.yml`. This should then fetch the content in the new `_includes/ucl-hpcc` folder and insert it into the relevant places like the standard Carpentries courses do.