### PR TITLE
Use the correct eventbrite variable name

### DIFF
--- a/index.md
+++ b/index.md
@@ -100,7 +100,7 @@ displayed if the 'eventbrite' field in the header is not set.
     window.EBWidgets.createWidget({
         // Required
         widgetType: 'checkout',
-        eventId: {{eventbrite}},
+        eventId: {{page.eventbrite}},
         iframeContainerId: 'eventbrite-widget-container',
     });
 </script>


### PR DESCRIPTION
The replacement of the eventbrite iframe with a div in commit ac6556b is based on a slightly different template from the Netherlands eScience center (https://github.com/esciencecenter-digital-skills/workshop-template). That version moves all of the variables from the top of index.md into a separate file. It adds some code to index.md that loads the data file and calls the variable `eventbrite`, but in the Carpentries version this is done at the top of index.md and the correct variable name is `page.eventbrite`. 