### PR TITLE
adding detailed schedule to workshop template for dc-astro curriculum

### DIFF
--- a/_includes/dc/schedule.html
+++ b/_includes/dc/schedule.html
@@ -10,27 +10,111 @@ The schedule for the different curricula are listed here:
 {% endcomment %}
 
 {% if site.curriculum == "dc-astronomy" %}
-<div class="row">
-  <div class="col-md-6">
+<div class="row">        <!-- first two days -->
+  <div class="col-md-6"> <!-- left column -->
     <h3>Day 1</h3>
     <table class="table table-striped">
-      <tr>
-	<td>Before starting</td>
-	<td><a href="{{ site.pre_survey }}{{ site.github.project_title }}" target="_blank">Pre-workshop survey</a></td>
+      <tr>               <!-- row 1   -->
+        <td>Before starting</td>
+        <td><a href="{{ site.pre_survey }}{{ site.github.project_title }}" target="_blank">Pre-workshop survey</a></td>
       </tr>
-      <tr><td>Morning</td> <td> <a href="https://datacarpentry.org/astronomy-python/01-query.html/">Basic Queries</a></td></tr>
-      <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/02-coords.html">Coordinate Transformations</a></td></tr>
-      <tr><td>Afternoon</td> <td> <a href="https://datacarpentry.org/astronomy-python/03-transform.html">Plotting and Tabular Data</a></td></tr>
-      <tr><td> </td> <td> <a href="https://datacarpentry.org/astronomy-python/04-motion.html">Plotting and Pandas</a></td></tr>
-    </table>
+      <tr>               <!-- row 2   -->
+        <td>8:00 am</td>        <!-- time    -->
+        <td>Optional Installation Help</td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 3   -->
+        <td>9:00 am</td>        <!-- time    -->
+        <td>Introduction</td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 4   -->
+        <td>9:30 am</td>        <!-- time    -->
+        <td><a href="https://datacarpentry.org/astronomy-python/instructor/01-query.html">Basic Queries</a></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 5   -->
+        <td>10:30 am</td>        <!-- time    -->
+        <td>Break</td>        <!-- content -->
+      </tr>
+    <tr>               <!-- row 6   -->
+      <td>11:00 am</td>        <!-- time    -->
+      <td><a href="https://datacarpentry.org/astronomy-python/instructor/01-query.html">Basic Queries Cont.</a></td>        <!-- content -->
+    </tr>
+    <tr>               <!-- row 7   -->
+      <td>11:30 am</td>        <!-- time    -->
+      <td><a href="https://datacarpentry.org/astronomy-python/instructor/02-coords.html">Coordinate Transformations</a></td>        <!-- content -->
+    </tr>
+    <tr>               <!-- row 8   -->
+      <td>12:00 pm</td>        <!-- time    -->
+      <td>Lunch</td>        <!-- content -->
+    </tr>
+    <tr>               <!-- row 9   -->
+      <td>1:00 pm</td>        <!-- time    -->
+      <td><a href="https://datacarpentry.org/astronomy-python/instructor/02-coords.html">Coordinate Transformations Cont.</a></td>        <!-- content -->
+    </tr>
+    <tr>               <!-- row 10   -->
+      <td>2:00 pm</td>        <!-- time    -->
+      <td><a href="https://datacarpentry.org/astronomy-python/instructor/03-transform.html">Plotting and Tabular Data</a></td>        <!-- content -->
+    </tr>
+    <tr>               <!-- row 11   -->
+      <td>3:00 pm</td>        <!-- time    -->
+      <td>Break</td>        <!-- content -->
+    </tr>
+    <tr>               <!-- row 12   -->
+      <td>3:30 pm</td>        <!-- time    -->
+      <td><a href="https://datacarpentry.org/astronomy-python/instructor/04-motion.html">Plotting and Pandas</a></td>        <!-- content -->
+    </tr>
+    <tr>               <!-- row 13   -->
+      <td>4:30 pm</td>        <!-- time    -->
+      <td>Wrap up</td>        <!-- content -->
+    </tr>
+    <tr>               <!-- row 14   -->
+      <td>5:00pm</td>        <!-- time    -->
+      <td>Done</td>        <!-- content -->
+    </tr>
+  </table>
   </div>
-  <div class="col-md-6">
+  <div class="col-md-6"> <!-- right column -->
     <h3>Day 2</h3>
     <table class="table table-striped">
-      <tr><td>Morning</td><td><a href="https://datacarpentry.org/astronomy-python/05-select.html">Transform and Select</a></td></tr>
-      <tr><td> </td> <td> <a href="https://datacarpentry.org/astronomy-python/06-join.html">Join</a></td></tr>
-      <tr><td>Afternoon</td><td><a href="https://datacarpentry.org/astronomy-python/07-photo.html">Photometry</a></td></tr>
-      <tr><td> </td><td><a href="https://datacarpentry.org/astronomy-python/08-plot.html">Visualization</a></td></tr>
+      <tr>               <!-- row 1   -->
+        <td>9:00am</td>        <!-- time    -->
+        <td><a href="https://datacarpentry.org/astronomy-python/instructor/05-select.html">Transform and Select</a></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 2   -->
+        <td>10:30 am</td>        <!-- time    -->
+        <td>Break</td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 3   -->
+        <td>11:00am</td>        <!-- time    -->
+        <td><a href="https://datacarpentry.org/astronomy-python/instructor/06-join.html">Join</a></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 4   -->
+        <td>12:30pm</td>        <!-- time    -->
+        <td>Lunch</td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 5   -->
+        <td>1:30pm</td>        <!-- time    -->
+        <td><a href="https://datacarpentry.org/astronomy-python/instructor/07-photo.html">Photometry</a></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 6   -->
+        <td>2:30pm</td>        <!-- time    -->
+        <td><a href="https://datacarpentry.org/astronomy-python/instructor/08-plot.html">Visualization</a></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 7   -->
+        <td>3:00pm</td>        <!-- time    -->
+        <td>Break</td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 8   -->
+        <td>3:30pm</td>        <!-- time    -->
+        <td><a href="https://datacarpentry.org/astronomy-python/instructor/08-plot.html">Visualization Cont</a></td>        <!-- content -->
+      </tr>
+      <tr>               <!-- row 9   -->
+        <td>4:45pm</td>        <!-- time    -->
+        <td><a href="{{ site.post_survey }}{{ site.github.project_title }}" target="_blank">Post-workshop survey</a></td>
+      </tr>
+      <tr>               <!-- row 10   -->
+        <td>5:00pm</td>        <!-- time    -->
+        <td>Done</td>        <!-- content -->
+      </tr>
     </table>
   </div>
 </div>


### PR DESCRIPTION
The dc-astro schedule in the template has only morning and afternoon listed. This is a more detailed schedule (along the lines of the SWC schedule) which is based on the estimated times in the lesson itself.