### PR TITLE
Update actions cache to v4

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Restore R Cache
         if: steps.check-rmd.outputs.count != 0
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}


### PR DESCRIPTION
This PR addresses actions/cache <v4 will be [deprecated in Feb 2025](https://github.com/actions/cache/discussions/categories/announcements).