### PR TITLE
updating line numbers referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ There are two ways of customizing your website. You can either:
 
 4.  Remove the notice about using the workshop template in the `index.md` file. You can safely
     delete everything between the `{% comment %}` and `{% endcomment %}` (included) as indicated
-    below (from line 35 to line 58):
+    below (from line 37 to line 60):
 
     ```jekyll
     {% comment %} <------------ remove from this line


### PR DESCRIPTION
Looks like the index.md template has changed a bit and in setting up my workshop the line numbers were 37-60. 