### PR TITLE
Run GitHub workflows on Ubuntu 22.04

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         lesson: [swcarpentry/shell-novice, datacarpentry/r-intro-geospatial, librarycarpentry/lc-git]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         experimental: [false]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             os-name: Linux
           - os: macos-latest
             os-name: macOS
@@ -31,12 +31,12 @@ jobs:
           - lesson: datacarpentry/astronomy-python
             lesson-name: (DC) Foundations of Astronomical Data Science
             experimental: true
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             os-name: Linux
           - lesson: carpentries/lesson-example
             lesson-name: (CP) Lesson Example
             experimental: false
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             os-name: Linux
     defaults:
       run:
@@ -176,7 +176,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd || echo "Nothing to update"
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "22.04"), sep = "\n")')
 
       - run: make site
         working-directory: lesson

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-website:
     if: ${{ !endsWith(github.repository, '/styles') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd || echo "Nothing to update"
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "22.04"), sep = "\n")')
 
       - name: Render the markdown and confirm that the site can be built
         run: make site


### PR DESCRIPTION
The Ubuntu 20.04 image was fully retired on 2025-04-15, see:

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

