### PR TITLE
Run GitHub workflows on Ubuntu 22.04

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         lesson: [swcarpentry/shell-novice, datacarpentry/r-intro-geospatial, librarycarpentry/lc-git]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         experimental: [false]
         include:
           - os: ubuntu-22.04

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -85,7 +85,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd || echo "Nothing to update"
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "22.04"), sep = "\n")')
 
       - name: Render the markdown and confirm that the site can be built
         run: make site


### PR DESCRIPTION
Some '20.04' instances were missed in commit 564660ad93d7ee3acf75d319dd25aa600d2efd40 .

The Ubuntu 20.04 image was fully retired on 2025-04-15, see:

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

@froggleston You won't steal my contributions that easily :laughing:  :rofl: 