### PR TITLE
Removing out of date video installation tutorials

### DIFF
--- a/_includes/install_instructions/editor.html
+++ b/_includes/install_instructions/editor.html
@@ -33,12 +33,6 @@
           for an example on how to open nano.
           It should be pre-installed.
         </p>
-        <h4 id="editor-macos-video-tutorial">Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/9LQhwETCdwY?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="editor-linux">
         <p>

--- a/_includes/install_instructions/git.html
+++ b/_includes/install_instructions/git.html
@@ -53,15 +53,8 @@ the text below accordingly.
           (Note: this project is no longer maintained.)
           Because this installer is not signed by the developer, you may have to
           right click (control click) on the .pkg file, click Open, and click
-          Open in the pop-up dialog. You can watch 
-          <a href="https://www.youtube.com/watch?v=9LQhwETCdwY ">a video tutorial about this case</a>.
+          Open in the pop-up dialog.
         </p>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-          <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/9LQhwETCdwY?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="git-linux">
         <p>

--- a/_includes/install_instructions/r.html
+++ b/_includes/install_instructions/r.html
@@ -28,12 +28,6 @@
           administrator" instead of double-clicking). Otherwise problems may occur later,
           for example when installing R packages.
         </p>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/q0PjTAylwoU?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="rstats-macos">
         <p>
@@ -43,12 +37,6 @@
           Also, please install the
           <a href="https://posit.co/download/rstudio-desktop/">RStudio IDE</a>.
         </p>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/5-ly3kyxwEg?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="rstats-linux">
         <p>

--- a/_includes/install_instructions/shell.html
+++ b/_includes/install_instructions/shell.html
@@ -97,12 +97,6 @@
 	  </li>
         </ol>
         <p>This will provide you with both Git and Bash in the Git Bash program.</p>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/339AEqk9c-8?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="shell-macos">
         <p>
@@ -129,12 +123,6 @@
           <kbd>Return</kbd> key and reboot.  To check available shells, type
           <code>cat /etc/shells</code>.
         </p>
-        <h4 id="shell-macos-video-tutorial">Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/9LQhwETCdwY?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="shell-linux">
         <p>


### PR DESCRIPTION
I think we should remove the old video tutorials.  I made them nearly 10 years ago.  If we decide we need them again, we should recreate them with the latest installation directions.

I believe this will close #821 and #450 