### PR TITLE
fix div id

### DIFF
--- a/_includes/lc/setup.html
+++ b/_includes/lc/setup.html
@@ -1,4 +1,4 @@
-<div id=""spreadsheets-setup">
+<div id="spreadsheets-setup">
   <h3>Spreadsheet Software</h3>
   <p>
     To interact with spreadsheets, we can use <a href="https://www.libreoffice.org">LibreOffice</a>, 


### PR DESCRIPTION
Remove superfluous quote mark. Closes https://github.com/carpentries/workshop-template/issues/860.