### PR TITLE
Install links and alert boxes

### DIFF
--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -59,7 +59,7 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
                     <li>Right click on the "Downloads" folder in the left-hand navigation pane</li>
                     <li>Select "Properties"</li>
                     <li>In the "Location" tab, ensure that the path is set to <code>C:\Users\[your-username]\Downloads</code></li>
-                    <img src="assets/img/onedrive_downloads_location.png" alt="OneDrive Downloads Location">
+                    <img src="/assets/img/onedrive_downloads_location.png" alt="OneDrive Downloads Location">
                   </ul>
                 </p>
                 <strong>If you encounter problems, please contact your IT support team and workshop organisers for assistance before the workshop.</strong>
@@ -105,7 +105,7 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
           <li>Search for the application "Miniforge Prompt", and click the icon to open it.
             <ul>
               <li>Once open, ensure the prompt shows your <code>C:\Users\[your-username]</code> folder. If it does, continue to Step 8 below:<br/>
-                <img src="assets/img/miniforge_prompt.png" alt="Miniforge Prompt [your-username] as froggleston"><br/>
+                <img src="/assets/img/miniforge_prompt.png" alt="Miniforge Prompt [your-username] as froggleston"><br/>
                 In this case, the prompt shows <code>C:\Users\froggleston</code>. Your username will be different!
               </li>
               <li>If it doesn't:
@@ -114,7 +114,7 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
                     <li>Your username will be shown as <code>[machine-name]\[your-username]</code>. You only need the <code>[your-username]</code> part after the slash, i.e. <code>froggleston</code> in this example.</li>
                     <li>Type <code>cd C:\Users\[your-username]</code> and press <kbd>Enter</kbd></li>
                 </ul>
-                <img src="assets/img/miniforge_prompt_whoami.png" alt="Miniforge Prompt whoami">
+                <img src="/assets/img/miniforge_prompt_whoami.png" alt="Miniforge Prompt whoami">
                 <ul>
                     <li>Continue to Step 8 below</li>
                 </ul>

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -52,7 +52,7 @@ $('.os-switch').click(function() {
   // hide alerts when site is rendered on carpentries.github.io
   $(document).ready(function() {
       if (location.href.startsWith("https://carpentries.github.io/workshop-template/")) {
-          $("div.alert").hide();
+          $("div.alert-danger").hide();
       }
   });
 </script>


### PR DESCRIPTION
The path used for images result in broken links on https://carpentries.github.io/workshop-template/#python-1. Switching to an absolute path solves the issue.

I also changed the scope of the alert box restriction on the template site. Since "alert-warning" boxes have now been used for things that aren't "instructions for people setting up the template", it doesn't make sense to hide them on the template site. See the OneDrive section at https://carpentries.github.io/workshop-template/#python-1 for an example how it's currently broken.
