### PR TITLE
add donate to navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -97,6 +97,8 @@
 
 	{% comment %} Always show license. {% endcomment %}
         <li><a href="{{ relative_root_path }}{% link LICENSE.md %}">License</a></li>
+        <li><a href="https://www.zeffy.com/en-US/donation-form/donate-to-make-a-difference-7497?utm_source=workshop-website">Donate</a></li>
+
         {% if site.life_cycle == 'transition-step-1' %}
         <li><a href="{{repo_url}}">Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
         {% elsif page.source == "Rmd" %}


### PR DESCRIPTION
Adds "donate" option to top menu bar.  

Preview:
<img width="1303" height="108" alt="image" src="https://github.com/user-attachments/assets/5f62036c-b2ab-4551-a348-02fcaa272756" />

Note the `utm` parameter include in the url: https://www.zeffy.com/en-US/donation-form/donate-to-make-a-difference-7497?utm_source=workshop-website.  